### PR TITLE
Update to support SAML assertions from Salesforce

### DIFF
--- a/lib/onelogin/saml/response.rb
+++ b/lib/onelogin/saml/response.rb
@@ -29,6 +29,7 @@ module Onelogin::Saml
     def name_id
       @name_id ||= begin
         node = REXML::XPath.first(document, "/p:Response/a:Assertion[@ID='#{document.signed_element_id[1,document.signed_element_id.size]}']/a:Subject/a:NameID", { "p" => PROTOCOL, "a" => ASSERTION })
+        node ||=  REXML::XPath.first(document, "/p:Response[@ID='#{document.signed_element_id[1,document.signed_element_id.size]}']/a:Assertion/a:Subject/a:NameID", { "p" => PROTOCOL, "a" => ASSERTION })
         node.nil? ? nil : node.text
       end
     end


### PR DESCRIPTION
Updated library to support inclusive_namespaces and recognized NameID in Salesforce SAML assertions. This change depends on modifications made to the canonix library. I have sent a pull request for that as well. The current version that supports inclusive namespaces is here:

https://github.com/brendon/canonix/pull/1

This update will fail gracefully if the required changes aren't in the canonix library.

I also updated name_id identification to support assertions from Salesforce.

Greg
