### PR TITLE
handle query string in sso target url correctly

### DIFF
--- a/lib/onelogin/saml/authrequest.rb
+++ b/lib/onelogin/saml/authrequest.rb
@@ -20,7 +20,8 @@ module Onelogin::Saml
       deflated_request  = Zlib::Deflate.deflate(request, 9)[2..-5]
       base64_request    = Base64.encode64(deflated_request)
       encoded_request   = CGI.escape(base64_request)
-      request_params    = "?SAMLRequest=" + encoded_request
+      params_prefix     = (settings.idp_sso_target_url =~ /\?/) ? '&' : '?'
+      request_params    = "#{params_prefix}SAMLRequest=#{encoded_request}"
 
       params.each_pair do |key, value|
         request_params << "&#{key}=#{CGI.escape(value.to_s)}"

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -29,5 +29,25 @@ class RequestTest < Test::Unit::TestCase
       auth_url = Onelogin::Saml::Authrequest.new.create(settings, { :hello => nil })
       assert auth_url =~ /&hello=$/
     end
+
+    context "when the target url doesn't contain a query string" do
+      should "create the SAMLRequest parameter correctly" do
+        settings = Onelogin::Saml::Settings.new
+        settings.idp_sso_target_url = "http://stuff.com"
+  
+        auth_url = Onelogin::Saml::Authrequest.new.create(settings)
+        assert auth_url =~ /^http:\/\/stuff.com\?SAMLRequest/
+      end
+    end
+
+    context "when the target url contains a query string" do
+      should "create the SAMLRequest parameter correctly" do
+        settings = Onelogin::Saml::Settings.new
+        settings.idp_sso_target_url = "http://stuff.com?field=value"
+  
+        auth_url = Onelogin::Saml::Authrequest.new.create(settings)
+        assert auth_url =~ /^http:\/\/stuff.com\?field=value&SAMLRequest/
+      end
+    end
   end
 end


### PR DESCRIPTION
I'm currently dealing with an SSO target URL that contains a query-string, eg http://test.com/sso/?key=value

In these instances use `&SAMLRequest=` rather than `?SAMLRequest=` when building the auth request URL
