### PR TITLE
Fixes dynamic NS bug in InclusiveNamespaces element query

### DIFF
--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -34,6 +34,7 @@ require "onelogin/ruby-saml/validation_error"
 module XMLSecurity
 
   class SignedDocument < REXML::Document
+    C14N = "http://www.w3.org/2001/10/xml-exc-c14n#"
     DSIG = "http://www.w3.org/2000/09/xmldsig#"
 
     attr_accessor :signed_element_id
@@ -64,14 +65,7 @@ module XMLSecurity
       # validate references
 
       # check for inclusive namespaces
-
-      inclusive_namespaces            = []
-      inclusive_namespace_element     = REXML::XPath.first(self, "//ec:InclusiveNamespaces")
-
-      if inclusive_namespace_element
-        prefix_list                   = inclusive_namespace_element.attributes.get_attribute('PrefixList').value
-        inclusive_namespaces          = prefix_list.split(" ")
-      end
+      inclusive_namespaces = extract_inclusive_namespaces
 
       # remove signature node
       sig_element = REXML::XPath.first(self, "//ds:Signature", {"ds"=>DSIG})
@@ -135,6 +129,15 @@ module XMLSecurity
       when 512 then OpenSSL::Digest::SHA512
       else
         OpenSSL::Digest::SHA1
+      end
+    end
+    
+    def extract_inclusive_namespaces
+      if element = REXML::XPath.first(self, "//ec:InclusiveNamespaces", { "ec" => C14N })
+        prefix_list = element.attributes.get_attribute("PrefixList").value
+        prefix_list.split(" ")
+      else
+        []
       end
     end
 

--- a/test/xml_security_test.rb
+++ b/test/xml_security_test.rb
@@ -68,5 +68,37 @@ class XmlSecurityTest < Test::Unit::TestCase
       assert @document.validate("F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72")
     end
   end
-
+  
+  context "XmlSecurity::SignedDocument" do
+    
+    context "#extract_inclusive_namespaces" do
+      should "support explicit namespace resolution for exclusive canonicalization" do
+        response = fixture(:open_saml_response, false)
+        document = XMLSecurity::SignedDocument.new(response)
+        inclusive_namespaces = document.send(:extract_inclusive_namespaces)
+        
+        assert_equal %w[ xs ], inclusive_namespaces
+      end
+      
+      should "support implicit namespace resolution for exclusive canonicalization" do
+        response = fixture(:no_signature_ns, false)
+        document = XMLSecurity::SignedDocument.new(response)
+        inclusive_namespaces = document.send(:extract_inclusive_namespaces)
+        
+        assert_equal %w[ #default saml ds xs xsi ], inclusive_namespaces
+      end
+      
+      should "return an empty list when inclusive namespace element is missing" do
+        response = fixture(:no_signature_ns, false)
+        response.slice! %r{<InclusiveNamespaces xmlns="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="#default saml ds xs xsi"/>}
+        
+        document = XMLSecurity::SignedDocument.new(response)
+        inclusive_namespaces = document.send(:extract_inclusive_namespaces)
+        
+        assert inclusive_namespaces.empty?
+      end
+    end
+    
+  end
+  
 end


### PR DESCRIPTION
extracts logic into a separate, private method. this allows us to test
the method in an isolated fashion and also shortens the lenght of the #validate_doc
method ( a little too long IMO ).
