### PR TITLE
Fixes bug with SignedDocument#validate_doc

### DIFF
--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -36,7 +36,7 @@ module XMLSecurity
   class SignedDocument < REXML::Document
     DSIG = "http://www.w3.org/2000/09/xmldsig#"
 
-    attr_accessor :signed_element_id
+    attr_accessor :signed_element_id, :sig_element
 
     def initialize(response)
       super(response)
@@ -73,9 +73,11 @@ module XMLSecurity
         inclusive_namespaces          = prefix_list.split(" ")
       end
 
-      # remove signature node
-      sig_element = REXML::XPath.first(self, "//ds:Signature", {"ds"=>DSIG})
-      sig_element.remove
+      # store and remove signature node
+      self.sig_element ||= begin
+        element = REXML::XPath.first(self, "//ds:Signature", {"ds"=>DSIG})
+        element.remove
+      end
 
       # check digests
       REXML::XPath.each(sig_element, "//ds:Reference", {"ds"=>DSIG}) do |ref|

--- a/test/xml_security_test.rb
+++ b/test/xml_security_test.rb
@@ -19,6 +19,12 @@ class XmlSecurityTest < Test::Unit::TestCase
         @document.validate_doc(@base64cert, false)
       end
     end
+    
+    should "not raise an error when softly validating the document multiple times" do
+      assert_nothing_raised do
+        2.times { @document.validate_doc(@base64cert, true) }
+      end
+    end
 
     should "should raise Fingerprint mismatch" do
       exception = assert_raise(Onelogin::Saml::ValidationError) do


### PR DESCRIPTION
calling this method more than once would result in an exception being
thrown because the signature node is removed from the root document in the first
invocation.

this node is being stored in an attr_accessor because subsequent calls to
the #validate_doc method need it to function properly.
