### PR TITLE
Fixes bug in Response#conditions

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -69,7 +69,8 @@ module Onelogin
       # Conditions (if any) for the assertion to run
       def conditions
         @conditions ||= begin
-          REXML::XPath.first(document, "/p:Response/a:Assertion[@ID='#{document.signed_element_id}']/a:Conditions", { "p" => PROTOCOL, "a" => ASSERTION })
+          node = REXML::XPath.first(document, "/p:Response/a:Assertion[@ID='#{document.signed_element_id}']/a:Conditions", { "p" => PROTOCOL, "a" => ASSERTION })
+          node || REXML::XPath.first(document, "/p:Response[@ID='#{document.signed_element_id}']/a:Assertion/a:Conditions", { "p" => PROTOCOL, "a" => ASSERTION })
         end
       end
 

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -186,6 +186,18 @@ class RubySamlTest < Test::Unit::TestCase
         assert_equal "wibble", response.issuer
       end
     end
+    
+    context "#conditions" do
+      should "work when the signed element id references the Assertion element" do
+        response = Onelogin::Saml::Response.new(response_document)
+        assert_equal "Conditions", response.conditions.name
+      end
+      
+      should "work when the singned element id refrences the Response element" do
+        response = Onelogin::Saml::Response.new(fixture(:open_saml_response))
+        assert_equal "Conditions", response.conditions.name
+      end
+    end
 
   end
 end


### PR DESCRIPTION
Not unlike the NameID node, we need to query for the Conditions element assuming
that the `<Reference URI=""/>` value can point to either:

(a) the `<Assertion>` node or
(b) the document root `<Response>` node
