### PR TITLE
Updates Response#issuer

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -76,6 +76,7 @@ module Onelogin
       def issuer
         @issuer ||= begin
           node = REXML::XPath.first(document, "/p:Response/a:Issuer", { "p" => PROTOCOL, "a" => ASSERTION })
+          node ||= REXML::XPath.first(document, "/p:Response/a:Assertion/a:Issuer", { "p" => PROTOCOL, "a" => ASSERTION })
           node.nil? ? nil : node.text
         end
       end

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -181,7 +181,12 @@ class RubySamlTest < Test::Unit::TestCase
     end
 
     context "#issuer" do
-      should "return the issuer of the assertion" do
+      should "return the issuer inside the response assertion" do
+        response = Onelogin::Saml::Response.new(response_document)
+        assert_equal "https://app.onelogin.com/saml/metadata/13590", response.issuer
+      end
+      
+      should "return the issuer inside the response" do
         response = Onelogin::Saml::Response.new(response_document_2)
         assert_equal "wibble", response.issuer
       end


### PR DESCRIPTION
The `<Issuer>` node can be located inside either the `<Response>` node or the `<Response><Assertion>`.
this change checks it in both places and lends preference to the former.
