### PR TITLE
Use Time#iso8601 instead of strftime for generating iso8601 times.

### DIFF
--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -34,7 +34,7 @@ module Onelogin
 
       def create_authentication_xml_doc(settings)
         uuid = "_" + UUID.new.generate
-        time = Time.now.utc.strftime("%Y-%m-%dT%H:%M:%S")
+        time = Time.now.utc.iso8601
         # Create AuthnRequest root element using REXML 
         request_doc = REXML::Document.new
 

--- a/lib/onelogin/ruby-saml/logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/logoutrequest.rb
@@ -35,7 +35,7 @@ module Onelogin
 
       def create_unauth_xml_doc(settings, params)
 
-        time = Time.new().strftime("%Y-%m-%dT%H:%M:%S")
+        time = Time.now.utc.iso8601
 
         request_doc = REXML::Document.new
         root = request_doc.add_element "samlp:LogoutRequest", { "xmlns:samlp" => "urn:oasis:names:tc:SAML:2.0:protocol" }


### PR DESCRIPTION
Use Time#iso8601 instead of strftime for generating iso8601 times. Authrequest is generating timestamps with strftime in a wrong way (is not appending "Z").

I'm having issues for authenticating using simplesamlphp, so I think this pull request is good.

Thanks!
