### PR TITLE
Fix missing validation_error

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -126,7 +126,7 @@ module Onelogin
         if soft
           @schema.validate(@xml).map{ return false }
         else
-          @schema.validate(@xml).map{ |error| raise(Exception.new("#{error.message}\n\n#{@xml.to_s}")) }
+          @schema.validate(@xml).map{ |error| validation_error("#{error.message}\n\n#{@xml.to_s}") }
         end
       end
 


### PR DESCRIPTION
Response#validate_structure was raising Exception instead of ValidationError. This is causing 'raise when encountering a condition that prevents the document from being valid' to fail.
