### PR TITLE
Added settings.compress_request to permit uncompressed authrequests

### DIFF
--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -19,8 +19,8 @@ module Onelogin
 
         Logging.debug "Created AuthnRequest: #{request}"
 
-        deflated_request  = Zlib::Deflate.deflate(request, 9)[2..-5]
-        base64_request    = Base64.encode64(deflated_request)
+        request           = Zlib::Deflate.deflate(request, 9)[2..-5] if settings.compress_request
+        base64_request    = Base64.encode64(request)
         encoded_request   = CGI.escape(base64_request)
         params_prefix     = (settings.idp_sso_target_url =~ /\?/) ? '&' : '?'
         request_params    = "#{params_prefix}SAMLRequest=#{encoded_request}"

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -1,7 +1,8 @@
 module Onelogin
   module Saml
     class Settings
-      def initialize(config = {})
+      def initialize(overrides = {})
+        config = DEFAULTS.merge(overrides)
         config.each do |k,v|
           acc = "#{k.to_s}=".to_sym
           self.send(acc, v) if self.respond_to? acc
@@ -14,6 +15,11 @@ module Onelogin
       attr_accessor :name_identifier_value
       attr_accessor :sessionindex
       attr_accessor :assertion_consumer_logout_service_url
+      attr_accessor :compress_request
+
+      private
+      
+      DEFAULTS = {:compress_request => true}
     end
   end
 end

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -19,6 +19,18 @@ class RequestTest < Test::Unit::TestCase
       assert_match /^<samlp:AuthnRequest/, inflated
     end
 
+    should "create the SAMLRequest URL parameter without deflating" do
+      settings = Onelogin::Saml::Settings.new
+      settings.compress_request = false
+      settings.idp_sso_target_url = "http://example.com"
+      auth_url = Onelogin::Saml::Authrequest.new.create(settings)
+      assert auth_url =~ /^http:\/\/example\.com\?SAMLRequest=/
+      payload  = CGI.unescape(auth_url.split("=").last)
+      decoded  = Base64.decode64(payload)
+
+      assert_match /^<samlp:AuthnRequest/, decoded
+    end
+
     should "accept extra parameters" do
       settings = Onelogin::Saml::Settings.new
       settings.idp_sso_target_url = "http://example.com"


### PR DESCRIPTION
This is to play well with diagnostic tools like Firefox SAMLTracer.

Tests included.
