### PR TITLE
Fix for response condition validation based on responses I'm getting from OneLogin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ group :test do
   gem "rake"
   gem "mocha"
   gem "nokogiri"
+  gem "timecop"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require 'test/unit'
 require 'shoulda'
 require 'mocha'
 require 'ruby-debug'
+require 'timecop'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))

--- a/test/xml_security_test.rb
+++ b/test/xml_security_test.rb
@@ -119,12 +119,29 @@ class XmlSecurityTest < Test::Unit::TestCase
     end
 
     context "StarfieldTMS" do
-      should "be able to validate a response" do
-        response = Onelogin::Saml::Response.new(fixture(:starfield_response))
-        response.settings = Onelogin::Saml::Settings.new(
-          :idp_cert_fingerprint => "8D:BA:53:8E:A3:B6:F9:F1:69:6C:BB:D9:D8:BD:41:B3:AC:4F:9D:4D"
-        )
-        assert response.validate!
+      setup do
+        @response = Onelogin::Saml::Response.new(fixture(:starfield_response))
+        @response.settings = Onelogin::Saml::Settings.new(
+                                                          :idp_cert_fingerprint => "8D:BA:53:8E:A3:B6:F9:F1:69:6C:BB:D9:D8:BD:41:B3:AC:4F:9D:4D"
+                                                          )
+      end
+
+      should "be able to validate a good response" do
+        Timecop.freeze Time.parse('2012-11-28 17:55:00 UTC') do
+          assert @response.validate!
+        end
+      end
+
+      should "fail before response is valid" do
+        Timecop.freeze Time.parse('2012-11-20 17:55:00 UTC') do
+          assert ! @response.is_valid?
+        end
+      end
+
+      should "fail after response expires" do
+        Timecop.freeze Time.parse('2012-11-30 17:55:00 UTC') do
+          assert ! @response.is_valid?
+        end
       end
     end
 


### PR DESCRIPTION
Adds ability to parse out NotBefore and NotOnOrAfter for responses with signed Response element rather than signed Assertion element. Also abstracts out the retrieval of xpaths from within the signed Response/Assertion.

Also adds tests with Timecop to make sure NotBefore and NotOnOrAfter work, because existing tests failed once Time.now got past the short window of the test response.
