### PR TITLE
Fix IssueInstant date format

### DIFF
--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -34,7 +34,7 @@ module Onelogin
 
       def create_authentication_xml_doc(settings)
         uuid = "_" + UUID.new.generate
-        time = Time.now.utc.strftime("%Y-%m-%dT%H:%M:%S")
+        time = Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
         # Create AuthnRequest root element using REXML 
         request_doc = REXML::Document.new
 


### PR DESCRIPTION
I'm having problems trying to authenticate using ruby-saml, and after some investigation I've discovered that the timestamp format is incorrect for my IdP.

After some searching and looking for other SAML examples, I've start to believe that the timestamp format without the trailing 'Z' was in fact incorrect. So I'm proposing to fix this issue inside the gem.

There are something that I missing?
