### PR TITLE
Added an explicit validation error when the X509Certificate is missing from the SAML Reponse

### DIFF
--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -47,6 +47,7 @@ module XMLSecurity
     def validate(idp_cert_fingerprint, soft = true)
       # get cert from response
       cert_element = REXML::XPath.first(self, "//ds:X509Certificate", { "ds"=>DSIG })
+      raise Onelogin::Saml::ValidationError.new("Certificate element missing in response (ds:X509Certificate)") unless cert_element
       base64_cert  = cert_element.text
       cert_text    = Base64.decode64(base64_cert)
       cert         = OpenSSL::X509::Certificate.new(cert_text)

--- a/test/xml_security_test.rb
+++ b/test/xml_security_test.rb
@@ -51,6 +51,16 @@ class XmlSecurityTest < Test::Unit::TestCase
       end
       assert_equal("Key validation error", exception.message)
     end
+
+    should "raise validation error when the X509Certificate is missing" do
+      response = Base64.decode64(response_document)
+      response.sub!(/<ds:X509Certificate>.*<\/ds:X509Certificate>/, "")
+      document = XMLSecurity::SignedDocument.new(response)
+      exception = assert_raise(Onelogin::Saml::ValidationError) do
+        document.validate("a fingerprint", false) # The fingerprint isn't relevant to this test
+      end
+      assert_equal("Certificate element missing in response (ds:X509Certificate)", exception.message)
+    end
   end
 
   context "Algorithms" do


### PR DESCRIPTION
We were seeing the following error:

NoMethodError: undefined method `text' for nil:NilClass

This pull request makes the problem more explicit:

ValidationError: Certificate element missing in response (ds:X509Certificate)

Thanks for maintain this awesome library!
