### PR TITLE
Added the Destination attribute to the AuthnRequest

### DIFF
--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -42,6 +42,7 @@ module Onelogin
         root.attributes['ID'] = uuid
         root.attributes['IssueInstant'] = time
         root.attributes['Version'] = "2.0"
+        root.attributes['Destination'] = settings.idp_sso_target_url unless settings.idp_sso_target_url.nil?
 
         # Conditionally defined elements based on settings
         if settings.assertion_consumer_service_url != nil


### PR DESCRIPTION
We found a customer that rejected SP-initiated authentication unless the Destination attribute told them what endpoint we sent the request to.

This pull request adds the Destination attribute. It's actually not configurable behaviour. Is that a problem?

Thanks again for all your work on maintaining this project.
