### PR TITLE
Added settings option double_quote_xml_attribute_values

### DIFF
--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -13,6 +13,7 @@ module Onelogin
         params = {} if params.nil?
 
         request_doc = create_authentication_xml_doc(settings)
+        request_doc.context[:attribute_quote] = :quote if settings.double_quote_xml_attribute_values
 
         request = ""
         request_doc.write(request)

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -16,10 +16,11 @@ module Onelogin
       attr_accessor :sessionindex
       attr_accessor :assertion_consumer_logout_service_url
       attr_accessor :compress_request
+      attr_accessor :double_quote_xml_attribute_values
 
       private
       
-      DEFAULTS = {:compress_request => true}
+      DEFAULTS = {:compress_request => true, :double_quote_xml_attribute_values => false}
     end
   end
 end


### PR DESCRIPTION
We've found that some IdPs have problems with single quotes for attribute values in SP-initiated scenarios. That's why this pull request enables this behaviour to be configured.

Enjoy!
