### PR TITLE
Depends on constant that is only in nokogiri 1.5+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ group :test do
   gem "shoulda"
   gem "rake"
   gem "mocha"
-  gem "nokogiri"
+  gem "nokogiri", ">= 1.5.0"
   gem "timecop"
 end

--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("canonix", ["0.1.1"])
   s.add_runtime_dependency("uuid", ["~> 2.3"])
-  s.add_runtime_dependency("nokogiri")
+  s.add_runtime_dependency("nokogiri", [">= 1.5.0"])
 end


### PR DESCRIPTION
I ran into this when including into an app that already was locked at a nokogiri 1.4.x version.  It gave the following error:

 uninitialized constant Nokogiri::XML::XML_C14N_EXCLUSIVE_1_0

That constant came into being with nokogiri 1.5, so this should depend on that.
