### PR TITLE
Fix for Tivoli Identity Manager

### DIFF
--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -81,7 +81,7 @@ module XMLSecurity
 
 
       # verify signature
-      signed_info_element     = REXML::XPath.first(@sig_element, "//ds:SignedInfo", {"ds"=>DSIG})
+      signed_info_element     = REXML::XPath.first(@sig_element, "//ds:SignedInfo")
       noko_sig_element = document.at_xpath('//ds:Signature', 'ds' => DSIG)
       noko_signed_info_element = noko_sig_element.at_xpath('./ds:SignedInfo', 'ds' => DSIG)
       canon_algorithm = canon_algorithm REXML::XPath.first(@sig_element, '//ds:CanonicalizationMethod', 'ds' => DSIG)
@@ -106,7 +106,7 @@ module XMLSecurity
         end
       end
 
-      base64_signature        = REXML::XPath.first(@sig_element, "//ds:SignatureValue", {"ds"=>DSIG}).text
+      base64_signature        = REXML::XPath.first(@sig_element, "//ds:SignatureValue").text
       signature               = Base64.decode64(base64_signature)
 
       # get certificate object
@@ -114,7 +114,7 @@ module XMLSecurity
       cert                    = OpenSSL::X509::Certificate.new(cert_text)
 
       # signature method
-      signature_algorithm     = algorithm(REXML::XPath.first(signed_info_element, "//ds:SignatureMethod", {"ds"=>DSIG}))
+      signature_algorithm     = algorithm(REXML::XPath.first(signed_info_element, "//ds:SignatureMethod"))
 
       unless cert.public_key.verify(signature_algorithm.new, signature, canon_string)
         return soft ? false : (raise Onelogin::Saml::ValidationError.new("Key validation error"))


### PR DESCRIPTION
I had problem recently using saml-ruby logging in from a Tivoli Identity Manager. In order to get the authentication to complete, I had to make the changes in this commit. My understanding of the inner workings of the lib/xml_security.rb file is really non-existent and I have no idea if this is causing any issues with security or something else.

Can someone please have a look at see if I've improved things or severely broken them. Thank you. 
