### PR TITLE
Soft validate with missing cert shouldn't raise error

### DIFF
--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -47,7 +47,12 @@ module XMLSecurity
     def validate_document(idp_cert_fingerprint, soft = true)
       # get cert from response
       cert_element = REXML::XPath.first(self, "//ds:X509Certificate", { "ds"=>DSIG })
-      raise OneLogin::RubySaml::ValidationError.new("Certificate element missing in response (ds:X509Certificate)") unless cert_element
+
+      unless cert_element
+        return soft ? false : raise(OneLogin::RubySaml::ValidationError.new("Certificate element missing in response (ds:X509Certificate)"))
+      end
+
+      # get info from cert
       base64_cert  = cert_element.text
       cert_text    = Base64.decode64(base64_cert)
       cert         = OpenSSL::X509::Certificate.new(cert_text)

--- a/test/xml_security_test.rb
+++ b/test/xml_security_test.rb
@@ -61,6 +61,13 @@ class XmlSecurityTest < Test::Unit::TestCase
       end
       assert_equal("Certificate element missing in response (ds:X509Certificate)", exception.message)
     end
+
+    should "fail soft validation without throwing error when the X509Certificate is missing" do
+      response = Base64.decode64(response_document)
+      response.sub!(/<ds:X509Certificate>.*<\/ds:X509Certificate>/, "")
+      document = XMLSecurity::SignedDocument.new(response)
+      document.validate_document("a fingerprint", true) # The fingerprint isn't relevant to this test
+    end
   end
 
   context "Algorithms" do


### PR DESCRIPTION
We should be able to soft validate without an exception being raised, which includes when the certificate is missing. This patch brings the behaviour of that validation inline with the fingerprint validation in the same method. (Returns false for soft validation, raises exception for non-soft validation.)
