### PR TITLE
Don't import open-uri

### DIFF
--- a/lib/onelogin/ruby-saml/logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/logoutresponse.rb
@@ -2,7 +2,6 @@ require "xml_security"
 require "time"
 require "base64"
 require "zlib"
-require "open-uri"
 
 module Onelogin
   module Saml


### PR DESCRIPTION
It isn't needed here anyway, and is extremely dangerous from a security
perspective - simply doing a `require 'ruby-saml'` causes every open() in
the calling program to suddenly start accepting any HTTP/FTP URIs, which
could be very surprising and unexpected.
