### PR TITLE
added namespace to xml query for digest algorithm

### DIFF
--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -96,7 +96,7 @@ module XMLSecurity
         canon_algorithm               = canon_algorithm REXML::XPath.first(ref, '//ds:CanonicalizationMethod', 'ds' => DSIG)
         canon_hashed_element          = hashed_element.canonicalize(canon_algorithm, inclusive_namespaces)
 
-        digest_algorithm              = algorithm(REXML::XPath.first(ref, "//ds:DigestMethod"))
+        digest_algorithm              = algorithm(REXML::XPath.first(ref, "//ds:DigestMethod", {"ds"=>DSIG}))
 
         hash                          = digest_algorithm.digest(canon_hashed_element)
         digest_value                  = Base64.decode64(REXML::XPath.first(ref, "//ds:DigestValue", {"ds"=>DSIG}).text)


### PR DESCRIPTION
According to issue #90 this fixed changes the namespace behaviour when using the SAML2 endpoint of AD-FS 2.0.
