### PR TITLE
Change time logoutrequest.rb to UTC Format

### DIFF
--- a/lib/onelogin/ruby-saml/logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/logoutrequest.rb
@@ -35,7 +35,7 @@ module Onelogin
 
       def create_unauth_xml_doc(settings, params)
 
-        time = Time.new().strftime("%Y-%m-%dT%H:%M:%S")
+	time = Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
 
         request_doc = REXML::Document.new
         root = request_doc.add_element "samlp:LogoutRequest", { "xmlns:samlp" => "urn:oasis:names:tc:SAML:2.0:protocol" }


### PR DESCRIPTION
Hi, I captured exception when tried use the logout url. I finded the error and I concluded is a error for the time format used in you gem. 

logoutrequest.rb

``` ruby
time = Time.new().strftime("%Y-%m-%dT%H:%M:%S")
```

I think you should add "Z" last the string %Y-%m-%dT%H:%M:%S. I read the documentation about Protocol SAML and they say:

SAML Protocol - Section 1.3.3 http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf
Icon

1.3.3 Time Values
All SAML time values have the type xs:dateTime, which is built in to the W3C XML Schema Datatypes
specification [Schema2], and MUST be expressed in UTC form, with no time zone component.
SAML system entities SHOULD NOT rely on time resolution finer than milliseconds. Implementations
MUST NOT generate time instants that specify leap seconds.
http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf

And the W3C XML say:

W3C XML - http://www.w3.org/TR/xmlschema-2/#isoformats
Icon

Z -- is used as time-zone designator, immediately (without a space) following a data element expressing the time of day in Coordinated Universal Time (UTC) in dateTime, time, date, gYearMonth, gMonthDay, gDay, gMonth, and gYear.

This is the error ocurred in my platform:

SimpleSAML_Error_Error: UNHANDLEDEXCEPTION

```
Backtrace:
1 /var/www/simplesamlphp/www/_include.php:37 (SimpleSAML_exception_handler)
0 [builtin] (N/A)
Caused by: Exception: Invalid SAML2 timestamp passed to parseSAML2Time: 2013-10-22T16:38:47
Backtrace:
6 /var/www/simplesamlphp/lib/SimpleSAML/Utilities.php:360 (SimpleSAML_Utilities::parseSAML2Time)
5 /var/www/simplesamlphp/lib/SAML2/Message.php:137 (SAML2_Message::__construct)
4 /var/www/simplesamlphp/lib/SAML2/LogoutRequest.php:51 (SAML2_LogoutRequest::__construct)
3 /var/www/simplesamlphp/lib/SAML2/Message.php:469 (SAML2_Message::fromXML)
2 /var/www/simplesamlphp/lib/SAML2/HTTPRedirect.php:125 (SAML2_HTTPRedirect::receive)
1 /var/www/simplesamlphp/modules/saml/lib/IdP/SAML2.php:436 (sspmod_saml_IdP_SAML2::receiveLogoutMessage)
0 /var/www/simplesamlphp/www/saml2/idp/SingleLogoutService.php:23 (N/A)
```

After of change line in code logoutrequest.rb, this error have solution.

Thank you!.
