### PR TITLE
Add validation hooks for assertion ID, time range, recipient, and destination

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -41,6 +41,20 @@ module Onelogin
         end
       end
 
+      def recipient
+        @recipient ||= begin
+          node = xpath_first_from_signed_assertion('/a:Subject/a:SubjectConfirmation/a:SubjectConfirmationData')
+          node.nil? ? nil : node.attributes['Recipient']
+        end
+      end
+
+      def destination
+        @destination ||= begin
+          node = REXML::XPath.first(document, "/p:Response", { "p" => PROTOCOL })
+          node.nil? ? nil : node.attributes['Destination']
+        end
+      end
+
       def sessionindex
         @sessionindex ||= begin
           node = xpath_first_from_signed_assertion('/a:AuthnStatement')
@@ -78,7 +92,7 @@ module Onelogin
           parse_time(node, "SessionNotOnOrAfter")
         end
       end
-      
+
       # Checks the status of the response for a "Success" code
       def success?
         @status_code ||= begin
@@ -110,10 +124,28 @@ module Onelogin
         validate_structure(soft)      &&
         validate_response_state(soft) &&
         validate_conditions(soft)     &&
-        document.validate(get_fingerprint, soft) && 
+        document.validate(get_fingerprint, soft) &&
         validate_new_assertion_id(soft) &&
         validate_time_range(soft)     &&
+        validate_recipient(soft) &&
+        validate_destination(soft) &&
         success?
+      end
+
+      def validate_recipient(soft = true)
+        valid = settings.recipient_validator.valid?(recipient, settings.assertion_consumer_service_url)
+        unless valid
+          return soft ? false : validation_error('Recipient and assertion consumer URL must match')
+        end
+        true
+      end
+
+      def validate_destination(soft = true)
+        valid = settings.destination_validator.valid?(destination, settings.assertion_consumer_service_url)
+        unless valid
+          return soft ? false : validation_error('Destination and assertion consumer URL must match')
+        end
+        true
       end
 
       # validate the time range using the validator (settings)

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -13,6 +13,18 @@ module Onelogin
       end
     end
 
+    class PermissiveRecipientValidator
+      def valid?(recipient_url, assertion_consumer_url)
+        true
+      end
+    end
+
+    class PermissiveDestinationValidator
+      def valid?(destination_url, assertion_consumer_url)
+        true
+      end
+    end
+
     class Settings
       def initialize(overrides = {})
         config = DEFAULTS.merge(overrides)
@@ -33,9 +45,16 @@ module Onelogin
       attr_accessor :assertion_id_validator
       attr_accessor :time_range_validator
       attr_accessor :passive
+      attr_accessor :destination_validator
+      attr_accessor :recipient_validator
       private
 
-      DEFAULTS = {:compress_request => true, :double_quote_xml_attribute_values => false, :assertion_id_validator => PermissiveAssertionIdValidator.new, :time_range_validator => PermissiveTimeRangeValidator.new}
+      DEFAULTS = {:compress_request                  => true,
+                  :double_quote_xml_attribute_values => false,
+                  :assertion_id_validator            => PermissiveAssertionIdValidator.new,
+                  :time_range_validator              => PermissiveTimeRangeValidator.new,
+                  :recipient_validator               => PermissiveRecipientValidator.new,
+                  :destination_validator             => PermissiveDestinationValidator.new}
     end
 
   end

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -1,13 +1,25 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 
-class CustomPermissiveAssertionIdValidator
+class FailingAssertionIdValidator
   def valid?(id)
     false
   end
 end
 
-class CustomPermissiveTimeRangeValidator
+class FailingTimeRangeValidator
   def valid?(begin_time, end_time)
+    false
+  end
+end
+
+class FailingRecipientValidator
+  def valid?(recipient_url, assertion_consumer_url)
+    false
+  end
+end
+
+class FailingDestinationValidator
+  def valid?(destination_url, assertion_consumer_url)
     false
   end
 end
@@ -136,28 +148,6 @@ class RubySamlTest < Test::Unit::TestCase
         assert response.validate!
       end
 
-      should "use the custom assertion id validator to validate the reponse" do
-        response = Onelogin::Saml::Response.new(fixture("no_signature_ns.xml"))
-        response.stubs(:conditions).returns(nil)
-        settings = Onelogin::Saml::Settings.new
-        settings.assertion_id_validator = CustomPermissiveAssertionIdValidator.new
-        response.settings = settings
-        settings.idp_cert_fingerprint = "28:74:9B:E8:1F:E8:10:9C:A8:7C:A9:C3:E3:C5:01:6C:92:1C:B4:BA"
-        XMLSecurity::SignedDocument.any_instance.expects(:validate_doc).returns(true)
-        assert_raises(Onelogin::Saml::ValidationError, 'Assertion ID can be use only once'){response.validate!}
-      end
-
-      should "use the custom time range validator to validate the reponse" do
-        response = Onelogin::Saml::Response.new(fixture("no_signature_ns.xml"))
-        response.stubs(:conditions).returns(nil)
-        settings = Onelogin::Saml::Settings.new
-        settings.time_range_validator = CustomPermissiveTimeRangeValidator.new
-        response.settings = settings
-        settings.idp_cert_fingerprint = "28:74:9B:E8:1F:E8:10:9C:A8:7C:A9:C3:E3:C5:01:6C:92:1C:B4:BA"
-        XMLSecurity::SignedDocument.any_instance.expects(:validate_doc).returns(true)
-        assert_raises(Onelogin::Saml::ValidationError, 'Time range validation failed'){response.validate!}
-      end
-
       should "validate ADFS assertions" do
         response = Onelogin::Saml::Response.new(fixture(:adfs_response_sha256))
         response.stubs(:conditions).returns(nil)
@@ -184,6 +174,45 @@ class RubySamlTest < Test::Unit::TestCase
         settings.idp_cert_fingerprint = signature_fingerprint_1
         response.settings = settings
         assert_raises(Onelogin::Saml::ValidationError, 'Digest mismatch'){ response.validate! }
+      end
+
+      context "with custom validators" do
+        setup do
+          @response = Onelogin::Saml::Response.new(fixture("no_signature_ns.xml"))
+          @response.stubs(:conditions).returns(nil)
+          @settings = Onelogin::Saml::Settings.new
+          @response.settings = @settings
+          @settings.idp_cert_fingerprint = "28:74:9B:E8:1F:E8:10:9C:A8:7C:A9:C3:E3:C5:01:6C:92:1C:B4:BA"
+          XMLSecurity::SignedDocument.any_instance.stubs(:validate_doc).returns(true)
+        end
+
+        should "fail assertion id validation appropriately" do
+          @settings.assertion_id_validator = FailingAssertionIdValidator.new
+          assert_raises(Onelogin::Saml::ValidationError, 'Assertion ID can be use only once') do
+            @response.validate!
+          end
+        end
+
+        should "fail time range validation appropriately" do
+          @settings.time_range_validator = FailingTimeRangeValidator.new
+          assert_raises(Onelogin::Saml::ValidationError, 'Time range validation failed') do
+            @response.validate!
+          end
+        end
+
+        should "fail recipient validation appropriately" do
+          @settings.recipient_validator = FailingRecipientValidator.new
+          assert_raises(Onelogin::Saml::ValidationError, 'Recipient and assertion consumer URL must match') do
+            @response.validate!
+          end
+        end
+
+        should "fail destination validation appropriately" do
+          @settings.destination_validator = FailingDestinationValidator.new
+          assert_raises(Onelogin::Saml::ValidationError, 'Destination and assertion consumer URL must match') do
+            @response.validate!
+          end
+        end
       end
     end
 
@@ -263,13 +292,13 @@ class RubySamlTest < Test::Unit::TestCase
         response = Onelogin::Saml::Response.new(response_document)
         assert_equal "https://app.onelogin.com/saml/metadata/13590", response.issuer
       end
-      
+
       should "return the issuer inside the response" do
         response = Onelogin::Saml::Response.new(response_document_2)
         assert_equal "wibble", response.issuer
       end
     end
-    
+
     context "#success" do
       should "find a status code that says success" do
         response = Onelogin::Saml::Response.new(response_document)


### PR DESCRIPTION
This ruby-saml gem has been really invaluable for implementing SAML in New Relic. Thanks so much for maintaining this. Along the way we've accumulated a few improvements to ruby-saml and it would be great if you could merge them in so that we can get back to tracking the master branch.

This pull request contains four additions:
1. A validation hook for the assertion ID. We found that we needed to ensure that we rejected reused assertion IDs so as to prevent replay attacks.
2. A validation hook for the time range conditions. We wanted to enforce sensible time range choices so that our customers wouldn't be unnecessarily weakening their security by making their assertions valid for long periods of time.
3. A validation hook for the recipient attribute. We wanted to protect our customers from attacks where an unauthorized user gains access by using a valid assertion for a different third-party Service Provider.
4. A validation hook for the destination attribute. Similar to #3, we wanted to protect our customers from attacks where an unauthorized user gains access by using a valid assertion for a different third-party Service Provider.

Sorry for putting this all in one pull request. If you need it broken out, just let me know.
