### PR TITLE
Authrequest date fix

### DIFF
--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -35,7 +35,7 @@ module Onelogin
 
       def create_authentication_xml_doc(settings)
         uuid = "_" + UUID.new.generate
-        time = Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+        time = Time.now.utc.strftime("%Y-%m-%dT%H:%M:%S%Z")
         # Create AuthnRequest root element using REXML
         request_doc = REXML::Document.new
 


### PR DESCRIPTION
Ran into some problems with Microsoft ADFS server drifting out of sync with time server. Led me to find this issue with the time format. This change fixes the broken times generated as "2014-02-23T15:30:00Z" so that it says instead "2014-02-23T15:30:00GMT" (or whatever actual time zone the server is configured to).

I would have written a test to demonstrate this, but the code was buried in a way that did not lend it self to a direct test, and I didn't know if I should refactor the code just to allow for a test.
