### PR TITLE
Add validation hooks for assertion ID, time range, recipient, and destination

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -135,6 +135,7 @@ module OneLogin
         validate_structure(soft)      &&
         validate_response_state(soft) &&
         validate_conditions(soft)     &&
+        validate_new_assertion_id(soft) &&
         document.validate_document(get_fingerprint, soft) &&
         validate_success_status(soft)
       end
@@ -179,6 +180,19 @@ module OneLogin
         node = REXML::XPath.first(document, "/p:Response/a:Assertion[@ID='#{document.signed_element_id}']#{subelt}", { "p" => PROTOCOL, "a" => ASSERTION })
         node ||= REXML::XPath.first(document, "/p:Response[@ID='#{document.signed_element_id}']/a:Assertion#{subelt}", { "p" => PROTOCOL, "a" => ASSERTION })
         node
+      end
+
+      def assertion_id
+        document.signed_element_id
+      end
+
+      # validate that we use the assertion id only once
+      def validate_new_assertion_id(soft = true)
+        valid = settings.assertion_id_validator.valid?(assertion_id)
+        unless valid
+          return soft ? false : validation_error("Assertion ID can be use only once")
+        end
+        true
       end
 
       def get_fingerprint

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -136,6 +136,7 @@ module OneLogin
         validate_response_state(soft) &&
         validate_conditions(soft)     &&
         validate_new_assertion_id(soft) &&
+        validate_time_range(soft)     &&
         document.validate_document(get_fingerprint, soft) &&
         validate_success_status(soft)
       end
@@ -146,6 +147,17 @@ module OneLogin
         else
           soft ? false : validation_error(status_message)
         end
+      end
+
+      # validate the time range using the validator (settings)
+      def validate_time_range(soft = true)
+        begin_time = parse_time(conditions, "NotBefore")
+        end_time = parse_time(conditions, "NotOnOrAfter")
+        valid = settings.time_range_validator.valid?(begin_time, end_time)
+        unless valid
+          return soft ? false : validation_error("Time range validation failed")
+        end
+        true
       end
 
       def validate_structure(soft = true)

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -41,6 +41,20 @@ module OneLogin
         end
       end
 
+      def recipient
+        @recipient ||= begin
+          node = xpath_first_from_signed_assertion('/a:Subject/a:SubjectConfirmation/a:SubjectConfirmationData')
+          node.nil? ? nil : node.attributes['Recipient']
+        end
+      end
+
+      def destination
+        @destination ||= begin
+          node = REXML::XPath.first(document, "/p:Response", { "p" => PROTOCOL })
+          node.nil? ? nil : node.attributes['Destination']
+        end
+      end
+
       def sessionindex
         @sessionindex ||= begin
           node = xpath_first_from_signed_assertion('/a:AuthnStatement')
@@ -132,11 +146,13 @@ module OneLogin
       end
 
       def validate(soft = true)
-        validate_structure(soft)      &&
-        validate_response_state(soft) &&
-        validate_conditions(soft)     &&
+        validate_structure(soft)        &&
+        validate_response_state(soft)   &&
+        validate_conditions(soft)       &&
+        validate_recipient(soft)        &&
+        validate_destination(soft)      &&
         validate_new_assertion_id(soft) &&
-        validate_time_range(soft)     &&
+        validate_time_range(soft)       &&
         document.validate_document(get_fingerprint, soft) &&
         validate_success_status(soft)
       end
@@ -147,6 +163,22 @@ module OneLogin
         else
           soft ? false : validation_error(status_message)
         end
+      end
+
+      def validate_recipient(soft = true)
+        valid = settings.recipient_validator.valid?(recipient, settings.assertion_consumer_service_url)
+        unless valid
+          return soft ? false : validation_error('Recipient and assertion consumer URL must match')
+        end
+        true
+      end
+
+      def validate_destination(soft = true)
+        valid = settings.destination_validator.valid?(destination, settings.assertion_consumer_service_url)
+        unless valid
+          return soft ? false : validation_error('Destination and assertion consumer URL must match')
+        end
+        true
       end
 
       # validate the time range using the validator (settings)

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -1,5 +1,11 @@
 module OneLogin
   module RubySaml
+    class PermissiveAssertionIdValidator
+      def valid?(id)
+        true
+      end
+    end
+
     class Settings
       def initialize(overrides = {})
         config = DEFAULTS.merge(overrides)
@@ -21,10 +27,11 @@ module OneLogin
       attr_accessor :protocol_binding
       attr_accessor :attributes_index
       attr_accessor :force_authn
+      attr_accessor :assertion_id_validator
 
       private
 
-      DEFAULTS = {:compress_request => true, :double_quote_xml_attribute_values => false}
+      DEFAULTS = {:compress_request => true, :double_quote_xml_attribute_values => false, :assertion_id_validator => PermissiveAssertionIdValidator.new}
     end
   end
 end

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -12,6 +12,18 @@ module OneLogin
       end
     end
 
+    class PermissiveRecipientValidator
+      def valid?(recipient_url, assertion_consumer_url)
+        true
+      end
+    end
+
+    class PermissiveDestinationValidator
+      def valid?(destination_url, assertion_consumer_url)
+        true
+      end
+    end
+
     class Settings
       def initialize(overrides = {})
         config = DEFAULTS.merge(overrides)
@@ -35,10 +47,20 @@ module OneLogin
       attr_accessor :force_authn
       attr_accessor :assertion_id_validator
       attr_accessor :time_range_validator
-
+      attr_accessor :passive
+      attr_accessor :destination_validator
+      attr_accessor :recipient_validator
+      
       private
 
-      DEFAULTS = {:compress_request => true, :double_quote_xml_attribute_values => false, :assertion_id_validator => PermissiveAssertionIdValidator.new, :time_range_validator => PermissiveTimeRangeValidator.new}
+      DEFAULTS = {
+        :compress_request                  => true,
+        :double_quote_xml_attribute_values => false,
+        :assertion_id_validator            => PermissiveAssertionIdValidator.new,
+        :time_range_validator              => PermissiveTimeRangeValidator.new,
+        :recipient_validator               => PermissiveRecipientValidator.new,
+        :destination_validator             => PermissiveDestinationValidator.new
+      }
     end
   end
 end

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -6,6 +6,12 @@ module OneLogin
       end
     end
 
+    class PermissiveTimeRangeValidator
+      def valid?(begin_time, end_time)
+        true
+      end
+    end
+
     class Settings
       def initialize(overrides = {})
         config = DEFAULTS.merge(overrides)
@@ -28,10 +34,11 @@ module OneLogin
       attr_accessor :attributes_index
       attr_accessor :force_authn
       attr_accessor :assertion_id_validator
+      attr_accessor :time_range_validator
 
       private
 
-      DEFAULTS = {:compress_request => true, :double_quote_xml_attribute_values => false, :assertion_id_validator => PermissiveAssertionIdValidator.new}
+      DEFAULTS = {:compress_request => true, :double_quote_xml_attribute_values => false, :assertion_id_validator => PermissiveAssertionIdValidator.new, :time_range_validator => PermissiveTimeRangeValidator.new}
     end
   end
 end

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -1,13 +1,25 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 
-class CustomPermissiveAssertionIdValidator
+class FailingAssertionIdValidator
   def valid?(id)
     false
   end
 end
 
-class CustomPermissiveTimeRangeValidator
+class FailingTimeRangeValidator
   def valid?(begin_time, end_time)
+    false
+  end
+end
+
+class FailingRecipientValidator
+  def valid?(recipient_url, assertion_consumer_url)
+    false
+  end
+end
+
+class FailingDestinationValidator
+  def valid?(destination_url, assertion_consumer_url)
     false
   end
 end
@@ -136,28 +148,6 @@ class RubySamlTest < Test::Unit::TestCase
         assert response.validate!
       end
 
-      should "use the custom assertion id validator to validate the reponse" do
-        response = Onelogin::Saml::Response.new(fixture("no_signature_ns.xml"))
-        response.stubs(:conditions).returns(nil)
-        settings = Onelogin::Saml::Settings.new
-        settings.assertion_id_validator = CustomPermissiveAssertionIdValidator.new
-        response.settings = settings
-        settings.idp_cert_fingerprint = "28:74:9B:E8:1F:E8:10:9C:A8:7C:A9:C3:E3:C5:01:6C:92:1C:B4:BA"
-        XMLSecurity::SignedDocument.any_instance.expects(:validate_doc).returns(true)
-        assert_raises(Onelogin::Saml::ValidationError, 'Assertion ID can be use only once'){response.validate!}
-      end
-
-      should "use the custom time range validator to validate the reponse" do
-        response = Onelogin::Saml::Response.new(fixture("no_signature_ns.xml"))
-        response.stubs(:conditions).returns(nil)
-        settings = Onelogin::Saml::Settings.new
-        settings.time_range_validator = CustomPermissiveTimeRangeValidator.new
-        response.settings = settings
-        settings.idp_cert_fingerprint = "28:74:9B:E8:1F:E8:10:9C:A8:7C:A9:C3:E3:C5:01:6C:92:1C:B4:BA"
-        XMLSecurity::SignedDocument.any_instance.expects(:validate_doc).returns(true)
-        assert_raises(Onelogin::Saml::ValidationError, 'Time range validation failed'){response.validate!}
-      end
-
       should "validate ADFS assertions" do
         response = OneLogin::RubySaml::Response.new(fixture(:adfs_response_sha256))
         response.stubs(:conditions).returns(nil)
@@ -184,6 +174,45 @@ class RubySamlTest < Test::Unit::TestCase
         settings.idp_cert_fingerprint = signature_fingerprint_1
         response.settings = settings
         assert_raises(OneLogin::RubySaml::ValidationError, 'Digest mismatch'){ response.validate! }
+      end
+
+      context "with custom validators" do
+        setup do
+          @response = OneLogin::RubySaml::Response.new(fixture("no_signature_ns.xml"))
+          @response.stubs(:conditions).returns(nil)
+          @settings = OneLogin::RubySaml::Settings.new
+          @response.settings = @settings
+          @settings.idp_cert_fingerprint = "28:74:9B:E8:1F:E8:10:9C:A8:7C:A9:C3:E3:C5:01:6C:92:1C:B4:BA"
+          XMLSecurity::SignedDocument.any_instance.stubs(:validate_doc).returns(true)
+        end
+
+        should "fail assertion id validation appropriately" do
+          @settings.assertion_id_validator = FailingAssertionIdValidator.new
+          assert_raises(OneLogin::RubySaml::ValidationError, 'Assertion ID can be use only once') do
+            @response.validate!
+          end
+        end
+
+        should "fail time range validation appropriately" do
+          @settings.time_range_validator = FailingTimeRangeValidator.new
+          assert_raises(OneLogin::RubySaml::ValidationError, 'Time range validation failed') do
+            @response.validate!
+          end
+        end
+
+        should "fail recipient validation appropriately" do
+          @settings.recipient_validator = FailingRecipientValidator.new
+          assert_raises(OneLogin::RubySaml::ValidationError, 'Recipient and assertion consumer URL must match') do
+            @response.validate!
+          end
+        end
+
+        should "fail destination validation appropriately" do
+          @settings.destination_validator = FailingDestinationValidator.new
+          assert_raises(OneLogin::RubySaml::ValidationError, 'Destination and assertion consumer URL must match') do
+            @response.validate!
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Originally at https://github.com/onelogin/ruby-saml/pull/103 - original description copied below:

This pull request contains four additions:
1. A validation hook for the assertion ID. We found that we needed to ensure that we rejected reused assertion IDs so as to prevent replay attacks.
2. A validation hook for the time range conditions. We wanted to enforce sensible time range choices so that our customers wouldn't be unnecessarily weakening their security by making their assertions valid for long periods of time.
3. A validation hook for the recipient attribute. We wanted to protect our customers from attacks where an unauthorized user gains access by using a valid assertion for a different third-party Service Provider.
4. A validation hook for the destination attribute. Similar to #3, we wanted to protect our customers from attacks where an unauthorized user gains access by using a valid assertion for a different third-party Service Provider.

All these additions are covered with new tests as well.