### PR TITLE
added missing namspaces argument

### DIFF
--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -96,7 +96,7 @@ module XMLSecurity
         canon_algorithm               = canon_algorithm REXML::XPath.first(ref, '//ds:CanonicalizationMethod', 'ds' => DSIG)
         canon_hashed_element          = hashed_element.canonicalize(canon_algorithm, inclusive_namespaces)
 
-        digest_algorithm              = algorithm(REXML::XPath.first(ref, "//ds:DigestMethod"))
+        digest_algorithm              = algorithm(REXML::XPath.first(ref, "//ds:DigestMethod", {"ds"=>DSIG}))
 
         hash                          = digest_algorithm.digest(canon_hashed_element)
         digest_value                  = Base64.decode64(REXML::XPath.first(ref, "//ds:DigestValue", {"ds"=>DSIG}).text)


### PR DESCRIPTION
I believe there's a missing namespace argument on digest algorithm lookup.  This change seems to fix the problem I was facing with an AD SAML integration, however I'm no SAML expert.
