### PR TITLE
Support AttributeConsumingServiceIndex in AuthnRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ class SamlController < ApplicationController
     settings.name_identifier_format         = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
     # Optional for most SAML IdPs
     settings.authn_context = "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"
+    # Optional. Describe according to IdP specification (if supported) which attributes the SP desires to receive in SAMLResponse.
+    settings.attributes_index = 30
 
     settings
   end

--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -46,6 +46,7 @@ module OneLogin
         root.attributes['Destination'] = settings.idp_sso_target_url unless settings.idp_sso_target_url.nil?
         root.attributes['IsPassive'] = settings.passive unless settings.passive.nil?
         root.attributes['ProtocolBinding'] = settings.protocol_binding unless settings.protocol_binding.nil?
+        root.attributes["AttributeConsumingServiceIndex"] = settings.attributes_index unless settings.attributes_index.nil?
 
         # Conditionally defined elements based on settings
         if settings.assertion_consumer_service_url != nil

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -19,6 +19,7 @@ module OneLogin
       attr_accessor :double_quote_xml_attribute_values
       attr_accessor :passive
       attr_accessor :protocol_binding
+      attr_accessor :attributes_index
 
       private
 

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -80,6 +80,22 @@ class RequestTest < Test::Unit::TestCase
       assert_match /<samlp:AuthnRequest[^<]* ProtocolBinding='urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'/, inflated
     end
 
+    should "create the SAMLRequest URL parameter with AttributeConsumingServiceIndex" do
+      settings = OneLogin::RubySaml::Settings.new
+      settings.idp_sso_target_url = "http://example.com"
+      settings.attributes_index = 30
+      auth_url = OneLogin::RubySaml::Authrequest.new.create(settings)
+      assert auth_url =~ /^http:\/\/example\.com\?SAMLRequest=/
+      payload  = CGI.unescape(auth_url.split("=").last)
+      decoded  = Base64.decode64(payload)
+
+      zstream  = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+      inflated = zstream.inflate(decoded)
+      zstream.finish
+      zstream.close
+      assert_match /<samlp:AuthnRequest[^<]* AttributeConsumingServiceIndex='30'/, inflated
+    end
+
     should "accept extra parameters" do
       settings = OneLogin::RubySaml::Settings.new
       settings.idp_sso_target_url = "http://example.com"

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -12,6 +12,7 @@ class SettingsTest < Test::Unit::TestCase
         :idp_sso_target_url, :idp_cert_fingerprint, :name_identifier_format,
         :idp_slo_target_url, :name_identifier_value, :sessionindex,
         :assertion_consumer_logout_service_url,
+        :attributes_index,
         :passive, :protocol_binding
       ]
 
@@ -32,6 +33,7 @@ class SettingsTest < Test::Unit::TestCase
           :idp_slo_target_url => "http://sso.muda.no/slo",
           :idp_cert_fingerprint => "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
           :name_identifier_format => "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+          :attributes_index => 30,
           :passive => true,
           :protocol_binding => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'
       }


### PR DESCRIPTION
Duplicate #95 but with rebased code

> As far as I can tell it currently isn't possible to set AttributeConsumingServiceIndex=some_value for an AuthnRequest, as I only see a mention of AttributeConsumingServiceIndex in the saml20protocol_schema.xsd.
> 
> I guess this could be implemented in a manner similar to IsPassive in 8a825f3 or https://github.com/onelogin/ruby-saml/issues/92 ?
