### PR TITLE
explicitly require "onelogin/ruby-saml/logging" 

### DIFF
--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -5,6 +5,8 @@ require "cgi"
 require "rexml/document"
 require "rexml/xpath"
 
+require "onelogin/ruby-saml/logging"
+
 module OneLogin
   module RubySaml
   include REXML

--- a/lib/onelogin/ruby-saml/metadata.rb
+++ b/lib/onelogin/ruby-saml/metadata.rb
@@ -2,6 +2,8 @@ require "rexml/document"
 require "rexml/xpath"
 require "uri"
 
+require "onelogin/ruby-saml/logging"
+
 # Class to return SP metadata based on the settings requested.
 # Return this XML in a controller, then give that URL to the the
 # IdP administrator.  The IdP will poll the URL and your settings


### PR DESCRIPTION
so that the developer may do:

``` Ruby
require 'onelogin/ruby-saml/authrequest'
```

instead of

``` Ruby
require 'onelogin/ruby-saml'
```

or

``` Ruby
require 'onelogin/ruby-saml/authrequest'
require 'onelogin/ruby-saml/logging'
```
