### PR TITLE
Add support for ForceAuthn on AuthRequests

### DIFF
--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -47,6 +47,7 @@ module OneLogin
         root.attributes['IsPassive'] = settings.passive unless settings.passive.nil?
         root.attributes['ProtocolBinding'] = settings.protocol_binding unless settings.protocol_binding.nil?
         root.attributes["AttributeConsumingServiceIndex"] = settings.attributes_index unless settings.attributes_index.nil?
+        root.attributes['ForceAuthn'] = settings.force_authn unless settings.force_authn.nil?
 
         # Conditionally defined elements based on settings
         if settings.assertion_consumer_service_url != nil

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -20,6 +20,7 @@ module OneLogin
       attr_accessor :passive
       attr_accessor :protocol_binding
       attr_accessor :attributes_index
+      attr_accessor :force_authn
 
       private
 

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -96,6 +96,22 @@ class RequestTest < Test::Unit::TestCase
       assert_match /<samlp:AuthnRequest[^<]* AttributeConsumingServiceIndex='30'/, inflated
     end
 
+    should "create the SAMLRequest URL parameter with ForceAuthn" do
+      settings = OneLogin::RubySaml::Settings.new
+      settings.idp_sso_target_url = "http://example.com"
+      settings.force_authn = true
+      auth_url = OneLogin::RubySaml::Authrequest.new.create(settings)
+      assert auth_url =~ /^http:\/\/example\.com\?SAMLRequest=/
+      payload  = CGI.unescape(auth_url.split("=").last)
+      decoded  = Base64.decode64(payload)
+
+      zstream  = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+      inflated = zstream.inflate(decoded)
+      zstream.finish
+      zstream.close
+      assert_match /<samlp:AuthnRequest[^<]* ForceAuthn='true'/, inflated
+    end
+
     should "accept extra parameters" do
       settings = OneLogin::RubySaml::Settings.new
       settings.idp_sso_target_url = "http://example.com"


### PR DESCRIPTION
Adds support for the optional `ForceAuthn` parameter in `AuthRequest` to indicate that the user should be required to reauthenticate rather than use a previous session.
