### PR TITLE
Nokogiri already in gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 group :test do
   if RUBY_VERSION < "1.9"
+    gem "nokogiri",   "~> 1.5.0"
     gem "ruby-debug", "~> 0.10.4"
   else
     gem "debugger",   "~> 1.1"


### PR DESCRIPTION
I don't think you need nokogiri in the gemfile and gemspec. This has caused us some pain because it is test scoped. 
