### PR TITLE
Fix incorrect gem declaration statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Using `Gemfile`
 gem 'ruby-saml', '~> 0.8.1'
 
 # or track master for bleeding-edge
-gem 'ruby-saml', git: 'onelogin/ruby-saml'
+gem 'ruby-saml', :github => 'onelogin/ruby-saml'
 ```
 
 Using Bundler


### PR DESCRIPTION
You should use the `github` option instead of the `git` option when
only writing the repo name.  Also, because we support ruby 1.8.7, it
should use the hashrocket syntax.
