### PR TITLE
Attributes method [] can raise NoMethodError

### DIFF
--- a/lib/onelogin/ruby-saml/attributes.rb
+++ b/lib/onelogin/ruby-saml/attributes.rb
@@ -47,7 +47,7 @@ module OneLogin
       
       # Return first value for an attribute
       def single(name)
-        attributes[canonize_name(name)].first if self.include?(name)
+        attributes[canonize_name(name)].first if include?(name)
       end
 
       # Return all values for an attribute


### PR DESCRIPTION
When `Attributes.single_value_compatibility = true`, calling attributes[:value] raises a NoMethodError is if the attribute hash key is not found. Fixes #156
