### PR TITLE
signature method in authrequest signing was always set to SHA1

### DIFF
--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -102,7 +102,7 @@ module XMLSecurity
       signature_element   = REXML::Element.new("Signature").add_namespace(DSIG)
       signed_info_element = signature_element.add_element("SignedInfo")
       signed_info_element.add_element("CanonicalizationMethod", {"Algorithm" => C14N})
-      signed_info_element.add_element("SignatureMethod", {"Algorithm"=>SHA1})
+      signed_info_element.add_element("SignatureMethod", {"Algorithm"=>signature_method})
 
       # Add Reference
       reference_element     = signed_info_element.add_element("Reference", {"URI" => "##{uuid}"})


### PR DESCRIPTION
Was always defaulting to SHA1 here, even when set to another method. Set it to the passed in parameter instead.
