### PR TITLE
Introduce thread safety to SAML schema validation

### DIFF
--- a/lib/onelogin/ruby-saml/saml_message.rb
+++ b/lib/onelogin/ruby-saml/saml_message.rb
@@ -1,8 +1,10 @@
 require 'cgi'
 require 'zlib'
 require 'base64'
+require "nokogiri"
 require "rexml/document"
 require "rexml/xpath"
+require "thread"
 
 module OneLogin
   module RubySaml
@@ -12,15 +14,20 @@ module OneLogin
       ASSERTION = "urn:oasis:names:tc:SAML:2.0:assertion"
       PROTOCOL  = "urn:oasis:names:tc:SAML:2.0:protocol"
 
-      def valid_saml?(document, soft = true)
-        Dir.chdir(File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'schemas'))) do
-          @schema = Nokogiri::XML::Schema(IO.read('saml-schema-protocol-2.0.xsd'))
-          @xml = Nokogiri::XML(document.to_s)
+      def self.schema
+        @schema ||= Mutex.new.synchronize do
+          Dir.chdir(File.expand_path("../../../schemas", __FILE__)) do
+            ::Nokogiri::XML::Schema(File.read("saml-schema-protocol-2.0.xsd"))
+          end
         end
-        if soft
-          @schema.validate(@xml).map{ return false }
-        else
-          @schema.validate(@xml).map{ |error| validation_error("#{error.message}\n\n#{@xml.to_s}") }
+      end
+
+      def valid_saml?(document, soft = true)
+        xml = Nokogiri::XML(document.to_s)
+
+        SamlMessage.schema.validate(xml).map do |error|
+          break false if soft
+          validation_error("#{error.message}\n\n#{xml.to_s}")
         end
       end
 


### PR DESCRIPTION
Per the references below, use of `Dir.chdir` is not thread-safe. This usage was causing exceptions to be raised when running on Puma and in other multi-threaded environments.

This patch also moves the schema read up to a class instance, as this data is static and does not need to be read every time an assertion is validated. This boosts performance, especially in environments with higher throughput.

Thanks to @dannyb for the assistance!

References:

* https://www.ruby-forum.com/topic/165079
* https://bugs.ruby-lang.org/issues/9785
* http://www.justskins.com/forums/working-directory-in-thread-42304.html
* http://www.ruby-doc.org/core-2.1.5/Dir.html#method-c-chdir