### PR TITLE
Add support for setting the entity ID and name ID format when parsing metadata

### DIFF
--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -25,7 +25,8 @@ module OneLogin
         @document = REXML::Document.new(idp_metadata)
 
         OneLogin::RubySaml::Settings.new.tap do |settings|
-
+          settings.idp_entity_id = idp_entity_id
+          settings.name_identifier_format = idp_name_id_format
           settings.idp_sso_target_url = single_signon_service_url
           settings.idp_slo_target_url = single_logout_service_url
           settings.idp_cert_fingerprint = fingerprint
@@ -55,6 +56,16 @@ module OneLogin
           meta_text = response.body
         end
         meta_text
+      end
+
+      def idp_entity_id
+        node = REXML::XPath.first(document, "/md:EntityDescriptor/@entityID", { "md" => METADATA })
+        node.value if node
+      end
+
+      def idp_name_id_format
+        node = REXML::XPath.first(document, "/md:EntityDescriptor/md:IDPSSODescriptor/md:NameIDFormat", { "md" => METADATA })
+        node.text if node
       end
 
       def single_signon_service_url

--- a/test/idp_metadata_parser_test.rb
+++ b/test/idp_metadata_parser_test.rb
@@ -14,9 +14,11 @@ class IdpMetadataParserTest < Test::Unit::TestCase
 
       settings = idp_metadata_parser.parse(idp_metadata)
 
+      assert_equal "https://example.hello.com/access/saml/idp.xml", settings.idp_entity_id
       assert_equal "https://example.hello.com/access/saml/login", settings.idp_sso_target_url
       assert_equal "F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72", settings.idp_cert_fingerprint
       assert_equal "https://example.hello.com/access/saml/logout", settings.idp_slo_target_url
+      assert_equal "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified", settings.name_identifier_format
     end
   end
 
@@ -37,9 +39,11 @@ class IdpMetadataParserTest < Test::Unit::TestCase
       idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
       settings = idp_metadata_parser.parse_remote(@url)
 
+      assert_equal "https://example.hello.com/access/saml/idp.xml", settings.idp_entity_id
       assert_equal "https://example.hello.com/access/saml/login", settings.idp_sso_target_url
       assert_equal "F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72", settings.idp_cert_fingerprint
       assert_equal "https://example.hello.com/access/saml/logout", settings.idp_slo_target_url
+      assert_equal "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified", settings.name_identifier_format
       assert_equal OpenSSL::SSL::VERIFY_PEER, @http.verify_mode
     end
 


### PR DESCRIPTION
Any reason we shouldn't do this?

Thanks for the gem, by the way! Great stuff.