### PR TITLE
Adding supported for Encrypted SAML 

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -18,12 +18,16 @@ module OneLogin
       attr_reader :options
       attr_reader :response
       attr_reader :document
-
+      attr_reader :decoded_response
+      attr_reader :decrypted_response
+      
       def initialize(response, options = {})
         @errors = []
         raise ArgumentError.new("Response cannot be nil") if response.nil?
         @options  = options
-        @response = decode_raw_saml(response)
+        @decoded_response = decode_raw_saml(response)
+        @decrypted_response = decrypt_saml(@decoded_response, @options[:private_key_file_path])
+        @response = @decrypted_response
         @document = XMLSecurity::SignedDocument.new(@response, @errors)
       end
 

--- a/lib/onelogin/ruby-saml/saml_message.rb
+++ b/lib/onelogin/ruby-saml/saml_message.rb
@@ -40,7 +40,8 @@ module OneLogin
 
       def decrypt_saml(decoded_saml, private_key_file_path=nil)
         noko_xml = Nokogiri::XML(decoded_saml)
-        if ((noko_xml.xpath('//saml:EncryptedAssertion', {:saml => "urn:oasis:names:tc:SAML:2.0:assertion"}).count > 0) && !private_key_file_path.nil?)
+        if (noko_xml.xpath('//saml:EncryptedAssertion', { :saml => ASSERTION }).count > 0)
+          raise ArgumentError, "Decryption Key File Path not provided for Encrypted Assertion" if private_key_file_path.nil?
           key_pem = File.read(private_key_file_path)
           encrypted_response = Xmlenc::EncryptedDocument.new(decoded_saml)
           private_key = OpenSSL::PKey::RSA.new(key_pem)

--- a/lib/onelogin/ruby-saml/saml_message.rb
+++ b/lib/onelogin/ruby-saml/saml_message.rb
@@ -5,6 +5,7 @@ require "nokogiri"
 require "rexml/document"
 require "rexml/xpath"
 require "thread"
+require "xmlenc"
 
 module OneLogin
   module RubySaml
@@ -39,9 +40,10 @@ module OneLogin
 
       def decrypt_saml(decoded_saml, private_key_file_path=nil)
         noko_xml = Nokogiri::XML(decoded_saml)
-        if (noko_xml.xpath('//saml:EncryptedAssertion', {:saml => "urn:oasis:names:tc:SAML:2.0:assertion"}).count > 0 && !private_key_file_path.nil?)
+        if ((noko_xml.xpath('//saml:EncryptedAssertion', {:saml => "urn:oasis:names:tc:SAML:2.0:assertion"}).count > 0) && !private_key_file_path.nil?)
+          key_pem = File.read(private_key_file_path)
           encrypted_response = Xmlenc::EncryptedDocument.new(decoded_saml)
-          private_key = OpenSSL::PKey::RSA.new(private_key_file_path)
+          private_key = OpenSSL::PKey::RSA.new(key_pem)
           return encrypted_response.decrypt(private_key)
         end
         return decoded_saml

--- a/lib/onelogin/ruby-saml/saml_message.rb
+++ b/lib/onelogin/ruby-saml/saml_message.rb
@@ -44,7 +44,13 @@ module OneLogin
           key_pem = File.read(private_key_file_path)
           encrypted_response = Xmlenc::EncryptedDocument.new(decoded_saml)
           private_key = OpenSSL::PKey::RSA.new(key_pem)
-          return encrypted_response.decrypt(private_key)
+          decrypted_string = encrypted_response.decrypt(private_key)
+          decrypted_string.gsub!('<?xml version="1.0"?>', '')
+          decrypted_string.gsub!('<Assertion', '<Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ')
+          decrypted_string.gsub!('<KeyInfo', '<KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#"> ')
+          decrypted_string.gsub!('<EncryptedAssertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion">', '')
+          decrypted_string.gsub!('</EncryptedAssertion>', '')
+          return decrypted_string.squish
         end
         return decoded_saml
       end

--- a/lib/onelogin/ruby-saml/saml_message.rb
+++ b/lib/onelogin/ruby-saml/saml_message.rb
@@ -45,12 +45,19 @@ module OneLogin
           encrypted_response = Xmlenc::EncryptedDocument.new(decoded_saml)
           private_key = OpenSSL::PKey::RSA.new(key_pem)
           decrypted_string = encrypted_response.decrypt(private_key)
-          decrypted_string.gsub!('<?xml version="1.0"?>', '')
-          decrypted_string.gsub!('<Assertion', '<Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ')
-          decrypted_string.gsub!('<KeyInfo', '<KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#"> ')
-          decrypted_string.gsub!('<EncryptedAssertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion">', '')
-          decrypted_string.gsub!('</EncryptedAssertion>', '')
-          return decrypted_string.squish
+          decrypted_doc = Nokogiri::XML(decrypted_string) do |config|
+            # config.strict.nonet # for an ideal world
+          end
+          saml_namespace = {:saml => "urn:oasis:names:tc:SAML:2.0:assertion"}
+          assertion = decrypted_doc.xpath("//saml:EncryptedAssertion/saml:Assertion", saml_namespace)
+          assertion = decrypted_doc.xpath("//saml:assertion", saml_namespace) if assertion.empty?
+          assertion = decrypted_doc.xpath("//saml:Assertion", saml_namespace) if assertion.empty?
+          assertion = decrypted_doc.xpath("//saml:ASSERTION", saml_namespace) if assertion.empty?
+          if assertion.empty?
+            validation_error("XML document seems to be malformed and does not have correct Nodes")
+          else
+            return assertion.first.to_s.gsub(" ", '').gsub("\n", '')
+          end
         end
         return decoded_saml
       end

--- a/lib/onelogin/ruby-saml/saml_message.rb
+++ b/lib/onelogin/ruby-saml/saml_message.rb
@@ -48,7 +48,7 @@ module OneLogin
           decrypted_doc = Nokogiri::XML(decrypted_string) do |config|
             # config.strict.nonet # for an ideal world
           end
-          saml_namespace = {:saml => "urn:oasis:names:tc:SAML:2.0:assertion"}
+          saml_namespace = { :saml => ASSERTION }
           assertion = decrypted_doc.xpath("//saml:EncryptedAssertion/saml:Assertion", saml_namespace)
           assertion = decrypted_doc.xpath("//saml:assertion", saml_namespace) if assertion.empty?
           assertion = decrypted_doc.xpath("//saml:Assertion", saml_namespace) if assertion.empty?

--- a/lib/onelogin/ruby-saml/saml_message.rb
+++ b/lib/onelogin/ruby-saml/saml_message.rb
@@ -37,6 +37,16 @@ module OneLogin
 
       private
 
+      def decrypt_saml(decoded_saml, private_key_file_path=nil)
+        noko_xml = Nokogiri::XML(decoded_saml)
+        if (noko_xml.xpath('//saml:EncryptedAssertion', {:saml => "urn:oasis:names:tc:SAML:2.0:assertion"}).count > 0 && !private_key_file_path.nil?)
+          encrypted_response = Xmlenc::EncryptedDocument.new(decoded_saml)
+          private_key = OpenSSL::PKey::RSA.new(private_key_file_path)
+          return encrypted_response.decrypt(private_key)
+        end
+        return decoded_saml
+      end
+      
       def decode_raw_saml(saml)
         if saml =~ /^</
           return saml

--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake',     '~> 10')
   s.add_development_dependency('shoulda',  '~> 2.11')
   s.add_development_dependency('systemu',  '~> 2')
-  s.add_development_dependency('timecop',  '<= 0.6.0')
+  s.add_development_dependency('timecop',  '~> 0.7.2')
 
   if RUBY_VERSION < '1.9'
     # 1.8.7

--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   if RUBY_VERSION < '1.9'
     # 1.8.7
     s.add_runtime_dependency('nokogiri', '~> 1.5.10')
-    s.add_development_dependency('timecop', '<=0.6.0')
+    s.add_development_dependency('timecop', '<= 0.6.0')
   else
     s.add_runtime_dependency('nokogiri', '~> 1.6.0')
     s.add_development_dependency('timecop',  '~> 0.7.2')

--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -29,8 +29,10 @@ Gem::Specification.new do |s|
   if RUBY_VERSION < '1.9'
     # 1.8.7
     s.add_runtime_dependency('nokogiri', '~> 1.5.10')
+    s.add_development_dependency('timecop', '<=0.6.0')
   else
     s.add_runtime_dependency('nokogiri', '~> 1.6.0')
+    s.add_development_dependency('timecop',  '~> 0.7.2')
   end
 
   s.add_development_dependency('minitest', '~> 5.5')
@@ -38,7 +40,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake',     '~> 10')
   s.add_development_dependency('shoulda',  '~> 2.11')
   s.add_development_dependency('systemu',  '~> 2')
-  s.add_development_dependency('timecop',  '~> 0.7.2')
 
   if RUBY_VERSION < '1.9'
     # 1.8.7

--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -54,4 +54,5 @@ Gem::Specification.new do |s|
     # 2.1.x, 2.2.x
     s.add_development_dependency('pry-byebug')
   end
+  s.add_runtime_dependency("xmlenc", ["~> 0.1.5"])
 end

--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files test/*`.split("\n")
 
   s.add_runtime_dependency('uuid', '~> 2.3')
+  s.add_runtime_dependency("xmlenc", ["~> 0.1.6"])
   if RUBY_VERSION < '1.9'
     # 1.8.7
     s.add_runtime_dependency('nokogiri', '~> 1.5.10')
@@ -55,5 +56,5 @@ Gem::Specification.new do |s|
     # 2.1.x, 2.2.x
     s.add_development_dependency('pry-byebug')
   end
-  s.add_runtime_dependency("xmlenc", ["~> 0.1.5"])
+
 end

--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files test/*`.split("\n")
 
   s.add_runtime_dependency('uuid', '~> 2.3')
-  s.add_runtime_dependency("xmlenc", ["~> 0.1.6"])
+  s.add_runtime_dependency("xmlenc", ["~> 0.1.7"])
   if RUBY_VERSION < '1.9'
     # 1.8.7
     s.add_runtime_dependency('nokogiri', '~> 1.5.10')


### PR DESCRIPTION
These changes are for adding support for **encrypted** SAML messages. [xmlenc] (https://github.com/digidentity/xmlenc) from has been used for encryption and decryption. All existing tests for ruby-saml are passing. I had to upgrade the timecop gem though, for the tests to pass on my local machine. Unfortunately these are failing on Travis CI for REE and 1.8.x 

@buffym @googya, could you please check and let me know if this works for your cases of Ping Federate and Encryption otherwise.

#9 #193 #186 #172 