### PR TITLE
Set default SSL certificate store in Ruby 1.8.

### DIFF
--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -47,6 +47,12 @@ module OneLogin
           # Most IdPs will probably use self signed certs
           if validate_cert
             http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+
+            # Net::HTTP in Ruby 1.8 did not set the default certificate store
+            # automatically when VERIFY_PEER was specified.
+            if RUBY_VERSION < '1.9' && !http.ca_file && !http.ca_path && !http.cert_store
+              http.cert_store = OpenSSL::SSL::SSLContext::DEFAULT_CERT_STORE
+            end
           else
             http.verify_mode = OpenSSL::SSL::VERIFY_NONE
           end


### PR DESCRIPTION
### Problem

`IdpMetadataParser#get_idp_metadata` ends up failing in Ruby 1.8 because Net::HTTP in Ruby 1.8 does not set the default SSL certificate store automatically when `VERIFY_PEER` is specified. Because of this, the method always fails with the following error because it is not able to verify that the SSL certificate is valid:

```
OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed
```

### Repro Steps

The quickest way to see the difference in behavior is to run the following snippet in Ruby 1.8.7 vs. any later version of Ruby:

```ruby
http = Net::HTTP.new('example.com', 443)
http.use_ssl = true
http.verify_mode = OpenSSL::SSL::VERIFY_PEER
get = Net::HTTP::Get.new('/')
response = http.request(get)
```

In Ruby 1.8.7, this results in the aforementioned error, whereas all later Ruby versions behave as expected and succeed:

```
 => #<Net::HTTPOK 200 OK readbody=true> 
```

### Cause

It looks like this is because in Ruby 1.9, [Net::HTTP began using `OpenSSL::SSL::SSLContext#set_params`](https://github.com/ruby/ruby/blob/v1_9_0_0/lib/net/http.rb#L586) to set SSL parameters in `Net::HTTP#connect`. The `#set_params` method [automatically sets the default certificate store](https://github.com/ruby/ruby/blob/v1_9_0_0/ext/openssl/lib/openssl/ssl.rb#L42) when it sees that `#verify_mode` is set to `VERIFY_PEER`. Net::HTTP in Ruby 1.8.7 did not call `#set_params`; rather it ended up [directly using the `SSLContext` object](https://github.com/ruby/ruby/blob/v1_8_7_374/lib/net/http.rb#L567) that was [created when `#use_ssl=` was called](https://github.com/ruby/ruby/blob/v1_8_7_374/lib/net/https.rb#L124).

### Fix

This fix sets the default SSL certificate store in Ruby 1.8 in the same manner `OpenSSL::SSL::SSLContext#set_params` tries to do when `validate_cert` is `true` in `IdpMetadataParser#get_idp_metadata`.