### PR TITLE
Freeze and duplicate default security settings hash so that it doesn't get modified.

### DIFF
--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -5,7 +5,10 @@ module OneLogin
         config = DEFAULTS.merge(overrides)
         config.each do |k,v|
           acc = "#{k.to_s}=".to_sym
-          self.send(acc, v) if self.respond_to? acc
+          if self.respond_to? acc
+            value = v.is_a?(Hash) ? v.dup : v
+            self.send(acc, value)
+          end
         end
         @attribute_consuming_service = AttributeService.new
       end
@@ -97,8 +100,8 @@ module OneLogin
       private
 
       DEFAULTS = {
-        :assertion_consumer_service_binding        => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-        :single_logout_service_binding             => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+        :assertion_consumer_service_binding        => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST".freeze,
+        :single_logout_service_binding             => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect".freeze,
         :compress_request                          => true,
         :compress_response                         => true,
         :security                                  => {
@@ -108,9 +111,9 @@ module OneLogin
           :embed_sign               => false,
           :digest_method            => XMLSecurity::Document::SHA1,
           :signature_method         => XMLSecurity::Document::SHA1
-        },
+        }.freeze,
         :double_quote_xml_attribute_values         => false,
-      }
+      }.freeze
     end
   end
 end

--- a/test/logoutrequest_test.rb
+++ b/test/logoutrequest_test.rb
@@ -104,6 +104,8 @@ class RequestTest < Minitest::Test
 
         inflated = decode_saml_request_payload(unauth_url)
         assert_match %r[<ds:SignatureValue>([a-zA-Z0-9/+=]+)</ds:SignatureValue>], inflated
+        assert_match %r[<ds:SignatureMethod Algorithm='http:\/\/www.w3.org\/2000\/09\/xmldsig#rsa-sha1'\/>], inflated
+        assert_match %r[<ds:DigestMethod Algorithm='http:\/\/www.w3.org\/2000\/09\/xmldsig#rsa-sha1'\/>], inflated
       end
 
       it "create a signed logout request with 256 digest and signature methods" do
@@ -123,8 +125,8 @@ class RequestTest < Minitest::Test
         request_xml = Base64.decode64(params["SAMLRequest"])
 
         assert_match %r[<ds:SignatureValue>([a-zA-Z0-9/+=]+)</ds:SignatureValue>], request_xml
-        request_xml =~ /<ds:SignatureMethod Algorithm='http:\/\/www.w3.org\/2001\/04\/xmldsig-more#rsa-sha256'\/>/
-        request_xml =~ /<ds:DigestMethod Algorithm='http:\/\/www.w3.org\/2001\/04\/xmldsig-more#rsa-sha512'\/>/
+        assert_match %r[<ds:SignatureMethod Algorithm='http:\/\/www.w3.org\/2001\/04\/xmldsig-more#rsa-sha256'\/>], request_xml
+        assert_match %r[<ds:DigestMethod Algorithm='http:\/\/www.w3.org\/2001\/04\/xmldsig-more#rsa-sha512'\/>], request_xml
       end
     end
 

--- a/test/logoutrequest_test.rb
+++ b/test/logoutrequest_test.rb
@@ -104,8 +104,8 @@ class RequestTest < Minitest::Test
 
         inflated = decode_saml_request_payload(unauth_url)
         assert_match %r[<ds:SignatureValue>([a-zA-Z0-9/+=]+)</ds:SignatureValue>], inflated
-        assert_match %r[<ds:SignatureMethod Algorithm='http:\/\/www.w3.org\/2000\/09\/xmldsig#rsa-sha1'\/>], inflated
-        assert_match %r[<ds:DigestMethod Algorithm='http:\/\/www.w3.org\/2000\/09\/xmldsig#rsa-sha1'\/>], inflated
+        assert_match %r[<ds:SignatureMethod Algorithm='http://www.w3.org/2000/09/xmldsig#rsa-sha1'/>], inflated
+        assert_match %r[<ds:DigestMethod Algorithm='http://www.w3.org/2000/09/xmldsig#rsa-sha1'/>], inflated
       end
 
       it "create a signed logout request with 256 digest and signature methods" do
@@ -125,8 +125,8 @@ class RequestTest < Minitest::Test
         request_xml = Base64.decode64(params["SAMLRequest"])
 
         assert_match %r[<ds:SignatureValue>([a-zA-Z0-9/+=]+)</ds:SignatureValue>], request_xml
-        assert_match %r[<ds:SignatureMethod Algorithm='http:\/\/www.w3.org\/2001\/04\/xmldsig-more#rsa-sha256'\/>], request_xml
-        assert_match %r[<ds:DigestMethod Algorithm='http:\/\/www.w3.org\/2001\/04\/xmldsig-more#rsa-sha512'\/>], request_xml
+        assert_match %r[<ds:SignatureMethod Algorithm='http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'/>], request_xml
+        assert_match %r[<ds:DigestMethod Algorithm='http://www.w3.org/2001/04/xmldsig-more#rsa-sha512'/>], request_xml
       end
     end
 

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -156,8 +156,8 @@ class RequestTest < Minitest::Test
         params = OneLogin::RubySaml::Authrequest.new.create_params(settings)
         request_xml = Base64.decode64(params["SAMLRequest"])
         assert_match %r[<ds:SignatureValue>([a-zA-Z0-9/+=]+)</ds:SignatureValue>], request_xml
-        request_xml =~ /<ds:SignatureMethod Algorithm='http:\/\/www.w3.org\/2000\/09\/xmldsig#rsa-sha1'\/>/
-        request_xml =~ /<ds:DigestMethod Algorithm='http:\/\/www.w3.org\/2000\/09\/xmldsig#rsa-sha1'\/>/
+        assert_match %r[<ds:SignatureMethod Algorithm='http:\/\/www.w3.org\/2000\/09\/xmldsig#rsa-sha1'\/>], request_xml
+        assert_match %r[<ds:DigestMethod Algorithm='http:\/\/www.w3.org\/2000\/09\/xmldsig#rsa-sha1'\/>], request_xml
       end
 
       it "create a signed request with 256 digest and signature methods" do
@@ -174,8 +174,8 @@ class RequestTest < Minitest::Test
         params = OneLogin::RubySaml::Authrequest.new.create_params(settings)
         request_xml = Base64.decode64(params["SAMLRequest"])
         assert_match %r[<ds:SignatureValue>([a-zA-Z0-9/+=]+)</ds:SignatureValue>], request_xml
-        request_xml =~ /<ds:SignatureMethod Algorithm='http:\/\/www.w3.org\/2001\/04\/xmldsig-more#rsa-sha256'\/>/
-        request_xml =~ /<ds:DigestMethod Algorithm='http:\/\/www.w3.org\/2001\/04\/xmldsig-more#rsa-sha512'\/>/
+        assert_match %r[<ds:SignatureMethod Algorithm='http:\/\/www.w3.org\/2001\/04\/xmldsig-more#rsa-sha256'\/>], request_xml
+        assert_match %r[<ds:DigestMethod Algorithm='http:\/\/www.w3.org\/2001\/04\/xmldsig-more#rsa-sha512'\/>], request_xml
       end
     end
 

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -156,8 +156,8 @@ class RequestTest < Minitest::Test
         params = OneLogin::RubySaml::Authrequest.new.create_params(settings)
         request_xml = Base64.decode64(params["SAMLRequest"])
         assert_match %r[<ds:SignatureValue>([a-zA-Z0-9/+=]+)</ds:SignatureValue>], request_xml
-        assert_match %r[<ds:SignatureMethod Algorithm='http:\/\/www.w3.org\/2000\/09\/xmldsig#rsa-sha1'\/>], request_xml
-        assert_match %r[<ds:DigestMethod Algorithm='http:\/\/www.w3.org\/2000\/09\/xmldsig#rsa-sha1'\/>], request_xml
+        assert_match %r[<ds:SignatureMethod Algorithm='http://www.w3.org/2000/09/xmldsig#rsa-sha1'/>], request_xml
+        assert_match %r[<ds:DigestMethod Algorithm='http://www.w3.org/2000/09/xmldsig#rsa-sha1'/>], request_xml
       end
 
       it "create a signed request with 256 digest and signature methods" do
@@ -174,8 +174,8 @@ class RequestTest < Minitest::Test
         params = OneLogin::RubySaml::Authrequest.new.create_params(settings)
         request_xml = Base64.decode64(params["SAMLRequest"])
         assert_match %r[<ds:SignatureValue>([a-zA-Z0-9/+=]+)</ds:SignatureValue>], request_xml
-        assert_match %r[<ds:SignatureMethod Algorithm='http:\/\/www.w3.org\/2001\/04\/xmldsig-more#rsa-sha256'\/>], request_xml
-        assert_match %r[<ds:DigestMethod Algorithm='http:\/\/www.w3.org\/2001\/04\/xmldsig-more#rsa-sha512'\/>], request_xml
+        assert_match %r[<ds:SignatureMethod Algorithm='http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'/>], request_xml
+        assert_match %r[<ds:DigestMethod Algorithm='http://www.w3.org/2001/04/xmldsig-more#rsa-sha512'/>], request_xml
       end
     end
 

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -61,5 +61,19 @@ class SettingsTest < Minitest::Test
       assert_equal @settings.attribute_consuming_service.name, "Test Service"
       assert_equal @settings.attribute_consuming_service.attributes, [{:name => "Name", :name_format => "Name Format", :friendly_name => "Friendly Name" }]
     end
+
+    it "does not modify default security settings" do
+      settings = OneLogin::RubySaml::Settings.new
+      settings.security[:authn_requests_signed] = true
+      settings.security[:embed_sign] = true
+      settings.security[:digest_method] = XMLSecurity::Document::SHA256
+      settings.security[:signature_method] = XMLSecurity::Document::SHA256
+
+      new_settings = OneLogin::RubySaml::Settings.new
+      assert_equal new_settings.security[:authn_requests_signed], false
+      assert_equal new_settings.security[:embed_sign], false
+      assert_equal new_settings.security[:digest_method], XMLSecurity::Document::SHA1
+      assert_equal new_settings.security[:signature_method], XMLSecurity::Document::SHA1
+    end
   end
 end


### PR DESCRIPTION
I noticed that there was no option to generate signed metadata and decided to come up with an implementation for it (to come in a later pull request). While doing this, I looked at how signatures were currently being tested for other generated XML and noticed that the tests weren't actually asserting that the signature/digest methods were correct; e.g., they were doing:

```ruby
request_xml =~ /<ds:SignatureMethod Algorithm='http:\/\/www.w3.org\/2000\/09\/xmldsig#rsa-sha1'\/>/
```

instead of:

```ruby
assert_match %r[<ds:SignatureMethod Algorithm='http://www.w3.org/2000/09/xmldsig#rsa-sha1'/>], request_xml
```

Once I fixed these tests though, I noticed that the ones looking for a SHA1 signature were failing because the XML that was being generated used SHA256 that was set by a different test.

### Cause

The reason for this was because `Settings#initialize` simply sets `#security` to the `DEFAULTS[:security]` hash. When one of the tests set `security[:signature_method] = XMLSecurity::Document::SHA256`, it ended up changing the `DEFAULTS[:security]` hash itself, so it ends up affecting all `Settings` objects.

I added this test to `settings_test.rb` to clearly expose the issue:

```ruby
it "does not modify default security settings" do
  settings = OneLogin::RubySaml::Settings.new
  settings.security[:authn_requests_signed] = true
  settings.security[:embed_sign] = true
  settings.security[:digest_method] = XMLSecurity::Document::SHA256
  settings.security[:signature_method] = XMLSecurity::Document::SHA256

  new_settings = OneLogin::RubySaml::Settings.new
  assert_equal new_settings.security[:authn_requests_signed], false
  assert_equal new_settings.security[:embed_sign], false
  assert_equal new_settings.security[:digest_method], XMLSecurity::Document::SHA1
  assert_equal new_settings.security[:signature_method], XMLSecurity::Document::SHA1
end
```

This test will fail without the fix I describe in the following section.

### Fix

Typically when creating defaults, `#freeze` should be called on any values that are mutable. This will prevent inadvertent modification of default values. When initializing an object to use these default values, `#dup` should be called to duplicate any of the default values you want to be mutable without affecting the original default value.