### PR TITLE
Require ‘net/http’ library

### DIFF
--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -2,6 +2,7 @@ require "base64"
 require "uuid"
 require "zlib"
 require "cgi"
+require 'net/http'
 require "rexml/document"
 require "rexml/xpath"
 

--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -2,8 +2,8 @@ require "base64"
 require "uuid"
 require "zlib"
 require "cgi"
-require 'net/http'
-require 'net/https'
+require "net/http"
+require "net/https"
 require "rexml/document"
 require "rexml/xpath"
 

--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -3,6 +3,7 @@ require "uuid"
 require "zlib"
 require "cgi"
 require 'net/http'
+require 'net/https'
 require "rexml/document"
 require "rexml/xpath"
 

--- a/test/idp_metadata_parser_test.rb
+++ b/test/idp_metadata_parser_test.rb
@@ -1,6 +1,4 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
-require 'net/http'
-require 'net/https'
 
 class IdpMetadataParserTest < Minitest::Test
 


### PR DESCRIPTION
The only place where `Net::HTTP` is used is in `lib/ruby-saml/idp_metadata_parser.rb`, so this is where I require the `net/http` library.