### PR TITLE
use SecureRandom.uuid and encapsulate uuid creation

### DIFF
--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -1,6 +1,5 @@
-require "uuid"
-
 require "onelogin/ruby-saml/logging"
+require "onelogin/ruby-saml/utils"
 
 module OneLogin
   module RubySaml
@@ -10,7 +9,7 @@ module OneLogin
       attr_reader :uuid # Can be obtained if neccessary
 
       def initialize
-        @uuid = "_" + UUID.new.generate
+        @uuid = OneLogin::RubySaml::Utils.uuid
       end
 
       def create(settings, params = {})

--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -1,5 +1,4 @@
 require "base64"
-require "uuid"
 require "zlib"
 require "cgi"
 require "net/http"

--- a/lib/onelogin/ruby-saml/logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/logoutrequest.rb
@@ -1,6 +1,5 @@
-require "uuid"
-
 require "onelogin/ruby-saml/logging"
+require "onelogin/ruby-saml/utils"
 
 module OneLogin
   module RubySaml
@@ -9,7 +8,7 @@ module OneLogin
       attr_reader :uuid # Can be obtained if neccessary
 
       def initialize
-        @uuid = "_" + UUID.new.generate
+        @uuid = OneLogin::RubySaml::Utils.uuid
       end
 
       def create(settings, params={})
@@ -79,7 +78,7 @@ module OneLogin
           name_id.text = settings.name_identifier_value
         else
           # If no NameID is present in the settings we generate one
-          name_id.text = "_" + UUID.new.generate
+          name_id.text = OneLogin::RubySaml::Utils.uuid
           name_id.attributes['Format'] = 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
         end
 

--- a/lib/onelogin/ruby-saml/slo_logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutresponse.rb
@@ -1,6 +1,5 @@
-require "uuid"
-
 require "onelogin/ruby-saml/logging"
+require "onelogin/ruby-saml/utils"
 
 module OneLogin
   module RubySaml
@@ -9,7 +8,7 @@ module OneLogin
       attr_reader :uuid # Can be obtained if neccessary
 
       def initialize
-        @uuid = "_" + UUID.new.generate
+        @uuid = OneLogin::RubySaml::Utils.uuid
       end
 
       def create(settings, request_id = nil, logout_message = nil, params = {})

--- a/lib/onelogin/ruby-saml/utils.rb
+++ b/lib/onelogin/ruby-saml/utils.rb
@@ -1,6 +1,11 @@
 module OneLogin
   module RubySaml
     class Utils
+
+      def self.uuid
+        "_#{SecureRandom.uuid}"
+      end
+
       def self.format_cert(cert, heads=true)
         cert = cert.delete("\n").delete("\r").delete("\x0D")
         if cert

--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -25,8 +25,6 @@ Gem::Specification.new do |s|
   s.summary = %q{SAML Ruby Tookit}
   s.test_files = `git ls-files test/*`.split("\n")
 
-  s.add_runtime_dependency('uuid', '~> 2.3')
-
   # Because runtime dependencies are determined at build time, we cannot make
   # Nokogiri's version dependent on the Ruby version, even though we would
   # have liked to constrain Ruby 1.8.7 to install only the 1.5.x versions.

--- a/test/logoutrequest_test.rb
+++ b/test/logoutrequest_test.rb
@@ -28,7 +28,7 @@ class RequestTest < Minitest::Test
 
     it "set sessionindex" do
       settings.idp_slo_target_url = "http://example.com"
-      sessionidx = UUID.new.generate
+      sessionidx = OneLogin::RubySaml::Utils.uuid
       settings.sessionindex = sessionidx
 
       unauth_url = OneLogin::RubySaml::Logoutrequest.new.create(settings, { :name_id => "there" })

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -113,7 +113,7 @@ class Minitest::Test
   # logoutresponse fixtures
   #
   def random_id
-    "_#{UUID.new.generate}"
+    "_#{OneLogin::RubySaml::Utils.uuid}"
   end
 
   #

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -1,0 +1,17 @@
+require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
+
+class UtilsTest < Minitest::Test
+
+  describe "Utils" do
+
+    describe ".uuid" do
+      it "returns a uuid starting with an underscore" do
+        assert_match /^_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/, OneLogin::RubySaml::Utils.uuid
+      end
+
+      it "doesn't return the same value twice" do
+        refute_equal OneLogin::RubySaml::Utils.uuid, OneLogin::RubySaml::Utils.uuid
+      end
+    end
+  end
+end


### PR DESCRIPTION
I removed the uuid gem dependency in favor of using SecureRandom and added a util method encapsulating the implementation.  This reduces the gems footprint and uses a random uuid that is not based on the mac address and time of creation, which I think is important for use in authentication.

If the different uuid version is a problem (I'm not as familiar with the requirements of SAML), it may be better to use the `uuidtools` gem over the `uuid` gem as it's more up to date and doesn't pull in as many dependencies.