### PR TITLE
Add ability to sign metadata. (Improved)

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,14 +336,17 @@ In order to be able to sign we need first to define the private key and the publ
 The settings related to sign are stored in the `security` attribute of the settings:
 
 ```ruby
-  settings.security[:authn_requests_signed]  = true     # Enable or not signature on AuthNRequest
-  settings.security[:logout_requests_signed] = true     # Enable or not signature on Logout Request
+  settings.security[:authn_requests_signed]   = true     # Enable or not signature on AuthNRequest
+  settings.security[:logout_requests_signed]  = true     # Enable or not signature on Logout Request
   settings.security[:logout_responses_signed] = true     # Enable or not signature on Logout Response
+  settings.security[:metadata_signed]         = true     # Enable or not signature on Metadata
 
   settings.security[:digest_method]    = XMLSecurity::Document::SHA1
   settings.security[:signature_method] = XMLSecurity::Document::SHA1
 
-  settings.security[:embed_sign]        = false                # Embeded signature or HTTP GET parameter Signature
+  # Embeded signature or HTTP GET parameter signature
+  # Note that metadata signature is always embedded regardless of this value.
+  settings.security[:embed_sign] = false
 ```
 
 

--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -113,7 +113,7 @@ module OneLogin
           end
         end
 
-        # embebed sign
+        # embed signature
         if settings.security[:authn_requests_signed] && settings.private_key && settings.certificate && settings.security[:embed_sign] 
           private_key = settings.get_sp_key()
           cert = settings.get_sp_cert()

--- a/lib/onelogin/ruby-saml/logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/logoutrequest.rb
@@ -89,7 +89,7 @@ module OneLogin
           sessionindex.text = settings.sessionindex
         end
 
-        # embebed sign
+        # embed signature
         if settings.security[:logout_requests_signed] && settings.private_key && settings.certificate && settings.security[:embed_sign]
           private_key = settings.get_sp_key()
           cert = settings.get_sp_cert()

--- a/lib/onelogin/ruby-saml/metadata.rb
+++ b/lib/onelogin/ruby-saml/metadata.rb
@@ -1,4 +1,5 @@
 require "uri"
+require "uuid"
 
 require "onelogin/ruby-saml/logging"
 
@@ -9,7 +10,7 @@ require "onelogin/ruby-saml/logging"
 module OneLogin
   module RubySaml
     class Metadata
-      def generate(settings)
+      def generate(settings, pretty_print=true)
         meta_doc = XMLSecurity::Document.new
         root = meta_doc.add_element "md:EntityDescriptor", {
             "xmlns:md" => "urn:oasis:names:tc:SAML:2.0:metadata"
@@ -20,6 +21,7 @@ module OneLogin
             # However we would like assertions signed if idp_cert_fingerprint or idp_cert is set
             "WantAssertionsSigned" => !!(settings.idp_cert_fingerprint || settings.idp_cert)
         }
+        root.attributes["ID"] = "_" + UUID.new.generate
         if settings.issuer
           root.attributes["entityID"] = settings.issuer
         end
@@ -91,7 +93,11 @@ module OneLogin
 
         ret = ""
         # pretty print the XML so IdP administrators can easily see what the SP supports
-        meta_doc.write(ret, 1)
+        if pretty_print
+          meta_doc.write(ret, 1)
+        else 
+          ret = meta_doc.to_s
+        end
 
         return ret
       end

--- a/lib/onelogin/ruby-saml/metadata.rb
+++ b/lib/onelogin/ruby-saml/metadata.rb
@@ -1,5 +1,3 @@
-require "rexml/document"
-require "rexml/xpath"
 require "uri"
 
 require "onelogin/ruby-saml/logging"
@@ -10,10 +8,9 @@ require "onelogin/ruby-saml/logging"
 # will be updated automatically
 module OneLogin
   module RubySaml
-    include REXML
     class Metadata
       def generate(settings)
-        meta_doc = REXML::Document.new
+        meta_doc = XMLSecurity::Document.new
         root = meta_doc.add_element "md:EntityDescriptor", {
             "xmlns:md" => "urn:oasis:names:tc:SAML:2.0:metadata"
         }
@@ -85,6 +82,13 @@ module OneLogin
         #  <md:XACMLAuthzDecisionQueryDescriptor WantAssertionsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"/>
 
         meta_doc << REXML::XMLDecl.new("1.0", "UTF-8")
+
+        # embed signature
+        if settings.security[:metadata_signed] && settings.private_key && settings.certificate
+          private_key = settings.get_sp_key()
+          meta_doc.sign_document(private_key, cert, settings.security[:signature_method], settings.security[:digest_method])
+        end
+
         ret = ""
         # pretty print the XML so IdP administrators can easily see what the SP supports
         meta_doc.write(ret, 1)

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -111,7 +111,8 @@ module OneLogin
         :security                                  => {
           :authn_requests_signed    => false,
           :logout_requests_signed   => false,
-          :logout_responses_signed   => false,
+          :logout_responses_signed  => false,
+          :metadata_signed          => false,
           :embed_sign               => false,
           :digest_method            => XMLSecurity::Document::SHA1,
           :signature_method         => XMLSecurity::Document::RSA_SHA1

--- a/lib/onelogin/ruby-saml/slo_logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutresponse.rb
@@ -87,7 +87,7 @@ module OneLogin
           issuer.text = settings.issuer
         end
 
-        # embebed sign
+        # embed signature
         if settings.security[:logout_responses_signed] && settings.private_key && settings.certificate && settings.security[:embed_sign]
           private_key = settings.get_sp_key()
           cert = settings.get_sp_cert()

--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -56,8 +56,9 @@ module XMLSecurity
       algorithm = element
       if algorithm.is_a?(REXML::Element)
         algorithm = element.attribute("Algorithm").value
-        algorithm = algorithm && algorithm =~ /sha(.*?)$/i && $1.to_i
       end
+
+      algorithm = algorithm && algorithm =~ /(rsa-)?sha(.*?)$/i && $2.to_i
 
       case algorithm
       when 256 then OpenSSL::Digest::SHA256
@@ -80,7 +81,7 @@ module XMLSecurity
     SHA384          = "http://www.w3.org/2001/04/xmldsig-more#sha384"
     SHA512          = "http://www.w3.org/2001/04/xmldsig-more#sha512"
     ENVELOPED_SIG   = "http://www.w3.org/2000/09/xmldsig#enveloped-signature"
-    INC_PREFIX_LIST = "#default samlp saml ds xs xsi"
+    INC_PREFIX_LIST = "#default samlp saml ds xs xsi md"
 
     attr_accessor :uuid
 
@@ -119,8 +120,6 @@ module XMLSecurity
       # Add Transforms
       transforms_element = reference_element.add_element("ds:Transforms")
       transforms_element.add_element("ds:Transform", {"Algorithm" => ENVELOPED_SIG})
-      #transforms_element.add_element("ds:Transform", {"Algorithm" => C14N})
-      #transforms_element.add_element("ds:InclusiveNamespaces", {"xmlns" => C14N, "PrefixList" => INC_PREFIX_LIST})
       c14element = transforms_element.add_element("ds:Transform", {"Algorithm" => C14N})
       c14element.add_element("ec:InclusiveNamespaces", {"xmlns:ec" => C14N, "PrefixList" => INC_PREFIX_LIST})
 
@@ -133,6 +132,7 @@ module XMLSecurity
       noko_sig_element = Nokogiri.parse(signature_element.to_s)
       noko_signed_info_element = noko_sig_element.at_xpath('//ds:Signature/ds:SignedInfo', 'ds' => DSIG)
       canon_string = noko_signed_info_element.canonicalize(canon_algorithm(C14N))
+
       signature = compute_signature(private_key, algorithm(signature_method).new, canon_string)
       signature_element.add_element("ds:SignatureValue").text = signature
 
@@ -150,7 +150,11 @@ module XMLSecurity
       if issuer_element
         self.root.insert_after issuer_element, signature_element
       else
-        self.root.add_element(signature_element)
+        if sp_sso_descriptor = self.elements["/md:EntityDescriptor"]
+          self.root.insert_before sp_sso_descriptor, signature_element
+        else
+          self.root.add_element(signature_element)
+        end
       end
     end
 

--- a/test/logoutrequest_test.rb
+++ b/test/logoutrequest_test.rb
@@ -90,7 +90,7 @@ class RequestTest < Minitest::Test
       end
     end
 
-    describe "when the settings indicate to sign (embedded) the logout request" do
+    describe "when the settings indicate to sign (embedded) logout request" do
       it "created a signed logout request" do
         settings = OneLogin::RubySaml::Settings.new
         settings.idp_slo_target_url = "http://example.com?field=value"

--- a/test/logoutrequest_test.rb
+++ b/test/logoutrequest_test.rb
@@ -90,7 +90,7 @@ class RequestTest < Minitest::Test
       end
     end
 
-    describe "when the settings indicate to sign (embebed) the logout request" do
+    describe "when the settings indicate to sign (embedded) the logout request" do
       it "created a signed logout request" do
         settings = OneLogin::RubySaml::Settings.new
         settings.idp_slo_target_url = "http://example.com?field=value"

--- a/test/logoutrequest_test.rb
+++ b/test/logoutrequest_test.rb
@@ -146,13 +146,13 @@ class RequestTest < Minitest::Test
 
         params = OneLogin::RubySaml::Logoutrequest.new.create_params(settings)
         assert params['Signature']
-        assert params['SigAlg'] == XMLSecurity::Document::RSA_SHA1
+        assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA1
 
         # signature_method only affects the embedeed signature
         settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA256
         params = OneLogin::RubySaml::Logoutrequest.new.create_params(settings)
         assert params['Signature']
-        assert params['SigAlg'] == XMLSecurity::Document::RSA_SHA1
+        assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA1
       end
     end
 

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -5,86 +5,105 @@ require 'onelogin/ruby-saml/metadata'
 class MetadataTest < Minitest::Test
 
   describe 'Metadata' do
-    def setup
-      @settings = OneLogin::RubySaml::Settings.new
-      @settings.issuer = "https://example.com"
-      @settings.name_identifier_format = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
-      @settings.assertion_consumer_service_url = "https://foo.example/saml/consume"
-      @settings.security[:authn_requests_signed] = false
-    end
+    let(:settings)          { OneLogin::RubySaml::Settings.new }
+    let(:xml_text)          { OneLogin::RubySaml::Metadata.new.generate(settings) }
+    let(:xml_doc)           { REXML::Document.new(xml_text) }
+    let(:spsso_descriptor)  { REXML::XPath.first(xml_doc, "//md:SPSSODescriptor") }
+    let(:acs)               { REXML::XPath.first(xml_doc, "//md:AssertionConsumerService") }
 
-    it "generates Service Provider Metadata with X509Certificate" do
-      @settings.security[:authn_requests_signed] = true
-      @settings.certificate = ruby_saml_cert_text
-
-      xml_text = OneLogin::RubySaml::Metadata.new.generate(@settings)
-
-      # assert xml_text can be parsed into an xml doc
-      xml_doc = REXML::Document.new(xml_text)
-
-      spsso_descriptor = REXML::XPath.first(xml_doc, "//md:SPSSODescriptor")
-      assert_equal "true", spsso_descriptor.attribute("AuthnRequestsSigned").value
-
-      cert_node = REXML::XPath.first(xml_doc, "//md:KeyDescriptor/ds:KeyInfo/ds:X509Data/ds:X509Certificate", {
-        "md" => "urn:oasis:names:tc:SAML:2.0:metadata",
-        "ds" => "http://www.w3.org/2000/09/xmldsig#"
-      })
-      cert_text = cert_node.text
-      cert = OpenSSL::X509::Certificate.new(Base64.decode64(cert_text))
-      assert_equal ruby_saml_cert.to_der, cert.to_der
-    end
-
-    it "generates Service Provider Metadata" do
-      settings = OneLogin::RubySaml::Settings.new
+    before do
       settings.issuer = "https://example.com"
       settings.name_identifier_format = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
       settings.assertion_consumer_service_url = "https://foo.example/saml/consume"
-      settings.security[:authn_requests_signed] = false
+    end
 
-      xml_text = OneLogin::RubySaml::Metadata.new.generate(settings)
-
+    it "generates Service Provider Metadata" do
       # assert correct xml declaration
       start = "<?xml version='1.0' encoding='UTF-8'?>\n<md:EntityDescriptor"
       assert xml_text[0..start.length-1] == start
 
-      # assert xml_text can be parsed into an xml doc
-      xml_doc = REXML::Document.new(xml_text)
-
       assert_equal "https://example.com", REXML::XPath.first(xml_doc, "//md:EntityDescriptor").attribute("entityID").value
 
-      spsso_descriptor = REXML::XPath.first(xml_doc, "//md:SPSSODescriptor")
       assert_equal "urn:oasis:names:tc:SAML:2.0:protocol", spsso_descriptor.attribute("protocolSupportEnumeration").value
       assert_equal "false", spsso_descriptor.attribute("AuthnRequestsSigned").value
       assert_equal "false", spsso_descriptor.attribute("WantAssertionsSigned").value
 
       assert_equal "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress", REXML::XPath.first(xml_doc, "//md:NameIDFormat").text.strip
 
-      acs = REXML::XPath.first(xml_doc, "//md:AssertionConsumerService")
       assert_equal "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST", acs.attribute("Binding").value
       assert_equal "https://foo.example/saml/consume", acs.attribute("Location").value
     end
 
-    it "generates attribute service if configured" do
-      settings = OneLogin::RubySaml::Settings.new
-      settings.issuer = "https://example.com"
-      settings.name_identifier_format = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
-      settings.assertion_consumer_service_url = "https://foo.example/saml/consume"
-      settings.attribute_consuming_service.configure do
-        service_name "Test Service"
-        add_attribute(:name => "Name", :name_format => "Name Format", :friendly_name => "Friendly Name", :attribute_value => "Attribute Value")
+    describe "when auth requests are signed" do
+      let(:cert_node) do
+        REXML::XPath.first(
+          xml_doc,
+          "//md:KeyDescriptor/ds:KeyInfo/ds:X509Data/ds:X509Certificate",
+          "md" => "urn:oasis:names:tc:SAML:2.0:metadata",
+          "ds" => "http://www.w3.org/2000/09/xmldsig#"
+        )
+      end
+      let(:cert)  { OpenSSL::X509::Certificate.new(Base64.decode64(cert_node.text)) }
+
+      before do
+        settings.security[:authn_requests_signed] = true
+        settings.certificate = ruby_saml_cert_text
       end
 
-      xml_text = OneLogin::RubySaml::Metadata.new.generate(settings)
-      xml_doc = REXML::Document.new(xml_text)
-      acs = REXML::XPath.first(xml_doc, "//md:AttributeConsumingService")
-      assert_equal "true", acs.attribute("isDefault").value
-      assert_equal "1", acs.attribute("index").value
-      assert_equal REXML::XPath.first(xml_doc, "//md:ServiceName").text.strip, "Test Service"
-      req_attr = REXML::XPath.first(xml_doc, "//md:RequestedAttribute")
-      assert_equal "Name", req_attr.attribute("Name").value
-      assert_equal "Name Format", req_attr.attribute("NameFormat").value
-      assert_equal "Friendly Name", req_attr.attribute("FriendlyName").value
-      assert_equal "Attribute Value", REXML::XPath.first(xml_doc, "//md:AttributeValue").text.strip
+      it "generates Service Provider Metadata with X509Certificate" do
+        assert_equal "true", spsso_descriptor.attribute("AuthnRequestsSigned").value
+        assert_equal ruby_saml_cert.to_der, cert.to_der
+      end
+    end
+
+    describe "when attribute service is configured" do
+      let(:attr_svc)  { REXML::XPath.first(xml_doc, "//md:AttributeConsumingService") }
+      let(:req_attr)  { REXML::XPath.first(xml_doc, "//md:RequestedAttribute") }
+
+      before do
+        settings.attribute_consuming_service.configure do
+          service_name "Test Service"
+          add_attribute(:name => "Name", :name_format => "Name Format", :friendly_name => "Friendly Name", :attribute_value => "Attribute Value")
+        end
+      end
+
+      it "generates attribute service" do
+        assert_equal "true", attr_svc.attribute("isDefault").value
+        assert_equal "1", attr_svc.attribute("index").value
+        assert_equal REXML::XPath.first(xml_doc, "//md:ServiceName").text.strip, "Test Service"
+
+        assert_equal "Name", req_attr.attribute("Name").value
+        assert_equal "Name Format", req_attr.attribute("NameFormat").value
+        assert_equal "Friendly Name", req_attr.attribute("FriendlyName").value
+        assert_equal "Attribute Value", REXML::XPath.first(xml_doc, "//md:AttributeValue").text.strip
+      end
+    end
+
+    describe "when the settings indicate to sign (embedded) the metadata" do
+      before do
+        settings.security[:metadata_signed] = true
+        settings.certificate = ruby_saml_cert_text
+        settings.private_key = ruby_saml_key_text
+      end
+
+      it "creates a signed metadata" do
+        assert_match %r[<ds:SignatureValue>\s*([a-zA-Z0-9/+=]+)\s*</ds:SignatureValue>]m, xml_text
+        assert_match %r[<ds:SignatureMethod Algorithm='http://www.w3.org/2000/09/xmldsig#rsa-sha1'/>], xml_text
+        assert_match %r[<ds:DigestMethod Algorithm='http://www.w3.org/2000/09/xmldsig#rsa-sha1'/>], xml_text
+      end
+
+      describe "when digest and signature methods are specified" do
+        before do
+          settings.security[:signature_method] = XMLSecurity::Document::SHA256
+          settings.security[:digest_method] = XMLSecurity::Document::SHA512
+        end
+
+        it "creates a signed metadata with specified digest and signature methods" do
+          assert_match %r[<ds:SignatureValue>\s*([a-zA-Z0-9/+=]+)\s*</ds:SignatureValue>]m, xml_text
+          assert_match %r[<ds:SignatureMethod Algorithm='http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'/>], xml_text
+          assert_match %r[<ds:DigestMethod Algorithm='http://www.w3.org/2001/04/xmldsig-more#rsa-sha512'/>], xml_text
+        end
+      end
     end
   end
 end

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -97,7 +97,7 @@ class MetadataTest < Minitest::Test
       end
     end
 
-    describe "when the settings indicate to sign (embedded) the metadata" do
+    describe "when the settings indicate to sign (embedded) metadata" do
       before do
         settings.security[:metadata_signed] = true
         settings.certificate = ruby_saml_cert_text

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -21,7 +21,7 @@ class MetadataTest < Minitest::Test
       xml_text = OneLogin::RubySaml::Metadata.new.generate(settings, true)
       # assert correct xml declaration
       start = "<?xml version='1.0' encoding='UTF-8'?>\n<md:EntityDescriptor"
-      assert xml_text[0..start.length-1] == start
+      assert_equal xml_text[0..start.length-1],start
 
       assert_equal "https://example.com", REXML::XPath.first(xml_doc, "//md:EntityDescriptor").attribute("entityID").value
 
@@ -38,7 +38,7 @@ class MetadataTest < Minitest::Test
     it "generates Service Provider Metadata" do
       # assert correct xml declaration
       start = "<?xml version='1.0' encoding='UTF-8'?><md:EntityDescriptor"
-      assert xml_text[0..start.length-1] == start
+      assert_equal xml_text[0..start.length-1], start
 
       assert_equal "https://example.com", REXML::XPath.first(xml_doc, "//md:EntityDescriptor").attribute("entityID").value
 

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -145,7 +145,7 @@ class RequestTest < Minitest::Test
       end
     end
 
-    describe "when the settings indicate to sign (embebed) the request" do
+    describe "when the settings indicate to sign (embedded) the request" do
       it "create a signed request" do
         settings = OneLogin::RubySaml::Settings.new
         settings.compress_request = false

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -145,7 +145,7 @@ class RequestTest < Minitest::Test
       end
     end
 
-    describe "when the settings indicate to sign (embedded) the request" do
+    describe "when the settings indicate to sign (embedded) request" do
       it "create a signed request" do
         settings = OneLogin::RubySaml::Settings.new
         settings.compress_request = false

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -195,13 +195,13 @@ class RequestTest < Minitest::Test
 
         params = OneLogin::RubySaml::Authrequest.new.create_params(settings)
         assert params['Signature']
-        assert params['SigAlg'] == XMLSecurity::Document::RSA_SHA1
+        assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA1
 
         # signature_method only affects the embedeed signature
         settings.security[:signature_method] = XMLSecurity::Document::SHA256
         params = OneLogin::RubySaml::Authrequest.new.create_params(settings)
         assert params['Signature']
-        assert params['SigAlg'] == XMLSecurity::Document::RSA_SHA1
+        assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA1
       end
     end
 

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -121,7 +121,7 @@ class RubySamlTest < Minitest::Test
         settings.idp_cert_fingerprint = signature_fingerprint_1
         response.settings = settings
         assert response.is_valid?
-        assert response.name_id == "test@onelogin.com"
+        assert_equal response.name_id, "test@onelogin.com"
       end
 
       it "support dynamic namespace resolution on signature elements" do

--- a/test/slo_logoutresponse_test.rb
+++ b/test/slo_logoutresponse_test.rb
@@ -122,13 +122,13 @@ class SloLogoutresponseTest < Minitest::Test
         request = OneLogin::RubySaml::SloLogoutrequest.new(logout_request_document)
         params = OneLogin::RubySaml::SloLogoutresponse.new.create_params(settings, request.id, "Custom Logout Message")
         assert params['Signature']
-        assert params['SigAlg'] == XMLSecurity::Document::RSA_SHA1
+        assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA1
 
         # signature_method only affects the embedeed signature
         settings.security[:signature_method] = XMLSecurity::Document::SHA256
         params = OneLogin::RubySaml::SloLogoutresponse.new.create_params(settings, request.id, "Custom Logout Message")
         assert params['Signature']
-        assert params['SigAlg'] == XMLSecurity::Document::RSA_SHA1
+        assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA1
       end
     end
   end

--- a/test/slo_logoutresponse_test.rb
+++ b/test/slo_logoutresponse_test.rb
@@ -67,7 +67,7 @@ class SloLogoutresponseTest < Minitest::Test
       assert_match /<samlp:StatusMessage>Custom Logout Message<\/samlp:StatusMessage>/, inflated
     end
 
-    describe "when the settings indicate to sign (embedded) the logout response" do
+    describe "when the settings indicate to sign (embedded) logout response" do
       it "create a signed logout response" do
         settings = OneLogin::RubySaml::Settings.new
         settings.compress_response = false

--- a/test/slo_logoutresponse_test.rb
+++ b/test/slo_logoutresponse_test.rb
@@ -67,7 +67,7 @@ class SloLogoutresponseTest < Minitest::Test
       assert_match /<samlp:StatusMessage>Custom Logout Message<\/samlp:StatusMessage>/, inflated
     end
 
-    describe "when the settings indicate to sign (embebed) the logout response" do
+    describe "when the settings indicate to sign (embedded) the logout response" do
       it "create a signed logout response" do
         settings = OneLogin::RubySaml::Settings.new
         settings.compress_response = false


### PR DESCRIPTION
Related to #207.
Improved:
* Test: Added signature validation
* prettyprint optional on metadata generator in order to avoid signature validation problems.
* signature position fixed. Now is placed at the top,

Fix algorithm calculator. This method was wrong