### PR TITLE
Fix Http-Redirect Signature: SignAlg and RelayState issue and algorithm calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ The settings related to sign are stored in the `security` attribute of the setti
   settings.security[:logout_responses_signed] = true     # Enable or not signature on Logout Response
 
   settings.security[:digest_method]    = XMLSecurity::Document::SHA1
-  settings.security[:signature_method] = XMLSecurity::Document::SHA1
+  settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA1
 
   settings.security[:embed_sign]        = false                # Embeded signature or HTTP GET parameter Signature
 ```

--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -28,6 +28,8 @@ module OneLogin
 
       def create_params(settings, params={})
         params = {} if params.nil?
+        # Some ruby-saml versions uses :RelayState others use 'RelayState'
+        relay_state = params[:RelayState] || params['RelayState']
 
         request_doc = create_authentication_xml_doc(settings)
         request_doc.context[:attribute_quote] = :quote if settings.double_quote_xml_attribute_values
@@ -42,9 +44,9 @@ module OneLogin
         request_params = {"SAMLRequest" => base64_request}
 
         if settings.security[:authn_requests_signed] && !settings.security[:embed_sign] && settings.private_key
-          params['SigAlg']    = XMLSecurity::Document::RSA_SHA1
+          params['SigAlg']    = settings.security[:signature_method]
           url_string          = "SAMLRequest=#{CGI.escape(base64_request)}"
-          url_string         += "&RelayState=#{CGI.escape(params['RelayState'])}" if params['RelayState']
+          url_string         += "&RelayState=#{CGI.escape(relay_state)}" if relay_state
           url_string         += "&SigAlg=#{CGI.escape(params['SigAlg'])}"
           private_key         = settings.get_sp_key()
           signature           = private_key.sign(XMLSecurity::BaseDocument.new.algorithm(settings.security[:signature_method]).new, url_string)

--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -27,8 +27,9 @@ module OneLogin
       end
 
       def create_params(settings, params={})
-        params = {} if params.nil?
-        # Some ruby-saml versions uses :RelayState others use 'RelayState'
+        # The method expects :RelayState but sometimes we get 'RelayState' instead.
+        # Based on the HashWithIndifferentAccess value in Rails we could experience
+        # conflicts so this line will solve them.
         relay_state = params[:RelayState] || params['RelayState']
 
         request_doc = create_authentication_xml_doc(settings)

--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -46,8 +46,8 @@ module OneLogin
         if settings.security[:authn_requests_signed] && !settings.security[:embed_sign] && settings.private_key
           params['SigAlg']    = settings.security[:signature_method]
           url_string          = "SAMLRequest=#{CGI.escape(base64_request)}"
-          url_string         += "&RelayState=#{CGI.escape(relay_state)}" if relay_state
-          url_string         += "&SigAlg=#{CGI.escape(params['SigAlg'])}"
+          url_string         << "&RelayState=#{CGI.escape(relay_state)}" if relay_state
+          url_string         << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
           private_key         = settings.get_sp_key()
           signature           = private_key.sign(XMLSecurity::BaseDocument.new.algorithm(settings.security[:signature_method]).new, url_string)
           params['Signature'] = encode(signature)

--- a/lib/onelogin/ruby-saml/logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/logoutrequest.rb
@@ -44,8 +44,8 @@ module OneLogin
         if settings.security[:logout_requests_signed] && !settings.security[:embed_sign] && settings.private_key
           params['SigAlg']    = settings.security[:signature_method]
           url_string          = "SAMLRequest=#{CGI.escape(base64_request)}"
-          url_string         += "&RelayState=#{CGI.escape(relay_state)}" if relay_state
-          url_string         += "&SigAlg=#{CGI.escape(params['SigAlg'])}"
+          url_string         << "&RelayState=#{CGI.escape(relay_state)}" if relay_state
+          url_string         << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
           private_key         = settings.get_sp_key()
           signature           = private_key.sign(XMLSecurity::BaseDocument.new.algorithm(settings.security[:signature_method]).new, url_string)
           params['Signature'] = encode(signature)

--- a/lib/onelogin/ruby-saml/logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/logoutrequest.rb
@@ -25,8 +25,9 @@ module OneLogin
       end
 
       def create_params(settings, params={})
-        params = {} if params.nil?
-        # Some ruby-saml versions uses :RelayState others use 'RelayState'
+        # The method expects :RelayState but sometimes we get 'RelayState' instead.
+        # Based on the HashWithIndifferentAccess value in Rails we could experience
+        # conflicts so this line will solve them.
         relay_state = params[:RelayState] || params['RelayState']
 
         request_doc = create_logout_request_xml_doc(settings)

--- a/lib/onelogin/ruby-saml/slo_logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutresponse.rb
@@ -26,7 +26,9 @@ module OneLogin
       end
 
       def create_params(settings, request_id = nil, logout_message = nil, params = {})
-        # Some ruby-saml versions uses :RelayState others use 'RelayState'
+        # The method expects :RelayState but sometimes we get 'RelayState' instead.
+        # Based on the HashWithIndifferentAccess value in Rails we could experience
+        # conflicts so this line will solve them.
         relay_state = params[:RelayState] || params['RelayState']
 
         response_doc = create_logout_response_xml_doc(settings, request_id, logout_message)

--- a/lib/onelogin/ruby-saml/slo_logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutresponse.rb
@@ -45,8 +45,8 @@ module OneLogin
         if settings.security[:logout_responses_signed] && !settings.security[:embed_sign] && settings.private_key
           params['SigAlg']    = settings.security[:signature_method]
           url_string          = "SAMLResponse=#{CGI.escape(base64_response)}"
-          url_string         += "&RelayState=#{CGI.escape(relay_state)}" if relay_state
-          url_string         += "&SigAlg=#{CGI.escape(params['SigAlg'])}"
+          url_string         << "&RelayState=#{CGI.escape(relay_state)}" if relay_state
+          url_string         << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
           private_key         = settings.get_sp_key()
           signature           = private_key.sign(XMLSecurity::BaseDocument.new.algorithm(settings.security[:signature_method]).new, url_string)
           params['Signature'] = encode(signature)

--- a/lib/onelogin/ruby-saml/slo_logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutresponse.rb
@@ -26,7 +26,6 @@ module OneLogin
       end
 
       def create_params(settings, request_id = nil, logout_message = nil, params = {})
-        params = {} if params.nil?
         # Some ruby-saml versions uses :RelayState others use 'RelayState'
         relay_state = params[:RelayState] || params['RelayState']
 

--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -56,8 +56,9 @@ module XMLSecurity
       algorithm = element
       if algorithm.is_a?(REXML::Element)
         algorithm = element.attribute("Algorithm").value
-        algorithm = algorithm && algorithm =~ /sha(.*?)$/i && $1.to_i
       end
+
+      algorithm = algorithm && algorithm =~ /(rsa-)?sha(.*?)$/i && $2.to_i
 
       case algorithm
       when 256 then OpenSSL::Digest::SHA256

--- a/test/logoutrequest_test.rb
+++ b/test/logoutrequest_test.rb
@@ -132,28 +132,53 @@ class RequestTest < Minitest::Test
       end
     end
 
-    describe "when the settings indicate to sign the logout request" do
-      it "create a signature parameter" do
-        settings = OneLogin::RubySaml::Settings.new
-        settings.compress_request = false
-        settings.idp_slo_target_url = "http://example.com?field=value"
-        settings.name_identifier_value = "f00f00"
-        settings.security[:logout_requests_signed] = true
-        settings.security[:embed_sign] = false
-        settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA1
-        settings.certificate  = ruby_saml_cert_text
-        settings.private_key = ruby_saml_key_text
-
-        params = OneLogin::RubySaml::Logoutrequest.new.create_params(settings)
-        assert params['Signature']
-        assert params['SigAlg'] == XMLSecurity::Document::RSA_SHA1
-
-        # if signature_method changes, the SigAlg also changes
-        settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA256
-        params = OneLogin::RubySaml::Logoutrequest.new.create_params(settings)
-        assert params['Signature']
-        assert params['SigAlg'] == XMLSecurity::Document::RSA_SHA256
+    describe "#create_params when the settings indicate to sign the logout request" do
+      def setup
+        @settings = OneLogin::RubySaml::Settings.new
+        @settings.compress_request = false
+        @settings.idp_sso_target_url = "http://example.com?field=value"
+        @settings.name_identifier_value = "f00f00"
+        @settings.security[:logout_requests_signed] = true
+        @settings.security[:embed_sign] = false
+        @settings.certificate  = ruby_saml_cert_text
+        @settings.private_key = ruby_saml_key_text
+        @cert = OpenSSL::X509::Certificate.new(ruby_saml_cert_text)
       end
+
+      it "create a signature parameter with RSA_SHA1 and validate it" do
+        settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA1
+
+        params = OneLogin::RubySaml::Logoutrequest.new.create_params(@settings, :RelayState => 'http://example.com')
+        assert params['SAMLRequest']
+        assert params[:RelayState]
+        assert params['Signature']
+        assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA1
+
+        query_string = "SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
+        query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
+        query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
+
+        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        assert_equal signature_algorithm, OpenSSL::Digest::SHA1
+        assert @cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
+      end
+
+      it "create a signature parameter with RSA_SHA256 and validate it" do
+        @settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA256
+
+        params = OneLogin::RubySaml::Logoutrequest.new.create_params(@settings, :RelayState => 'http://example.com')
+        assert params['Signature']
+        assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA256
+
+        query_string = "SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
+        query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
+        query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
+
+        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        assert_equal signature_algorithm, OpenSSL::Digest::SHA256 
+        assert @cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string) 
+      end
+
     end
 
   end

--- a/test/logoutrequest_test.rb
+++ b/test/logoutrequest_test.rb
@@ -148,11 +148,11 @@ class RequestTest < Minitest::Test
         assert params['Signature']
         assert params['SigAlg'] == XMLSecurity::Document::RSA_SHA1
 
-        # signature_method only affects the embedeed signature
+        # if signature_method changes, the SigAlg also changes
         settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA256
         params = OneLogin::RubySaml::Logoutrequest.new.create_params(settings)
         assert params['Signature']
-        assert params['SigAlg'] == XMLSecurity::Document::RSA_SHA1
+        assert params['SigAlg'] == XMLSecurity::Document::RSA_SHA256
       end
     end
 

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -145,7 +145,7 @@ class RequestTest < Minitest::Test
       end
     end
 
-    describe "when the settings indicate to sign (embebed) the request" do
+    describe "#create_params when the settings indicate to sign (embebed) the request" do
       it "create a signed request" do
         settings = OneLogin::RubySaml::Settings.new
         settings.compress_request = false
@@ -181,27 +181,51 @@ class RequestTest < Minitest::Test
       end
     end
 
-    describe "when the settings indicate to sign the request" do
-      it "create a signature parameter" do
-        settings = OneLogin::RubySaml::Settings.new
-        settings.compress_request = false
-        settings.idp_sso_target_url = "http://example.com?field=value"
-        settings.assertion_consumer_service_binding = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign"
-        settings.security[:authn_requests_signed] = true
-        settings.security[:embed_sign] = false
-        settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA1
-        settings.certificate  = ruby_saml_cert_text
-        settings.private_key = ruby_saml_key_text
+    describe "#create_params when the settings indicate to sign the request" do
+      def setup
+        @settings = OneLogin::RubySaml::Settings.new
+        @settings.compress_request = false
+        @settings.idp_sso_target_url = "http://example.com?field=value"
+        @settings.assertion_consumer_service_binding = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign"
+        @settings.security[:authn_requests_signed] = true
+        @settings.security[:embed_sign] = false
+        @settings.certificate  = ruby_saml_cert_text
+        @settings.private_key = ruby_saml_key_text
+        @cert = OpenSSL::X509::Certificate.new(ruby_saml_cert_text)
+      end
+      
+      it "create a signature parameter with RSA_SHA1 and validate it" do
+        @settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA1
 
-        params = OneLogin::RubySaml::Authrequest.new.create_params(settings)
+        params = OneLogin::RubySaml::Authrequest.new.create_params(@settings, :RelayState => 'http://example.com')
+        assert params['SAMLRequest']
+        assert params[:RelayState]
         assert params['Signature']
-        assert params['SigAlg'] == XMLSecurity::Document::RSA_SHA1
+        assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA1
 
-        # if signature_method changes, the SigAlg also changes
-        settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA256
-        params = OneLogin::RubySaml::Authrequest.new.create_params(settings)
+        query_string = "SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
+        query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
+        query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
+
+        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        assert_equal signature_algorithm, OpenSSL::Digest::SHA1
+        assert @cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
+      end
+
+      it "create a signature parameter with RSA_SHA256 and validate it" do
+        @settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA256
+
+        params = OneLogin::RubySaml::Authrequest.new.create_params(@settings, :RelayState => 'http://example.com')
         assert params['Signature']
-        assert params['SigAlg'] == XMLSecurity::Document::RSA_SHA256
+        assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA256
+
+        query_string = "SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
+        query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
+        query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
+
+        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        assert_equal signature_algorithm, OpenSSL::Digest::SHA256
+        assert @cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)        
       end
     end
 

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -197,11 +197,11 @@ class RequestTest < Minitest::Test
         assert params['Signature']
         assert params['SigAlg'] == XMLSecurity::Document::RSA_SHA1
 
-        # signature_method only affects the embedeed signature
-        settings.security[:signature_method] = XMLSecurity::Document::SHA256
+        # if signature_method changes, the SigAlg also changes
+        settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA256
         params = OneLogin::RubySaml::Authrequest.new.create_params(settings)
         assert params['Signature']
-        assert params['SigAlg'] == XMLSecurity::Document::RSA_SHA1
+        assert params['SigAlg'] == XMLSecurity::Document::RSA_SHA256
       end
     end
 

--- a/test/slo_logoutresponse_test.rb
+++ b/test/slo_logoutresponse_test.rb
@@ -124,11 +124,11 @@ class SloLogoutresponseTest < Minitest::Test
         assert params['Signature']
         assert params['SigAlg'] == XMLSecurity::Document::RSA_SHA1
 
-        # signature_method only affects the embedeed signature
-        settings.security[:signature_method] = XMLSecurity::Document::SHA256
+        # if signature_method changes, the SigAlg also changes
+        settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA256
         params = OneLogin::RubySaml::SloLogoutresponse.new.create_params(settings, request.id, "Custom Logout Message")
         assert params['Signature']
-        assert params['SigAlg'] == XMLSecurity::Document::RSA_SHA1
+        assert params['SigAlg'] == XMLSecurity::Document::RSA_SHA256
       end
     end
   end


### PR DESCRIPTION
Now Signature algorithm 256, 384, 512 are supported on HTTP-Redirect Signatures (Tested with real IdPs). 

It was fixed a bug of mixing SHA1 and RSA_SHA1. algorithm and test were fixed.

We found a problem when creating the Signature, after some research we discovered that in some environments params['RelayState'] and params[:RelayState] are differents so Signatures were created without the RelayState parameter when keep sending a RelayState to the IdP, so the validation always failed. We added a compatibility line to fix that issue.