### PR TITLE
Add fingerprint algorithm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ def saml_settings
   settings.idp_sso_target_url             = "https://app.onelogin.com/trust/saml2/http-post/sso/#{OneLoginAppId}"
   settings.idp_slo_target_url             = "https://app.onelogin.com/trust/saml2/http-redirect/slo/#{OneLoginAppId}"
   settings.idp_cert_fingerprint           = OneLoginAppCertFingerPrint
-  settings.idp_cert_fingerprint_alg       = "http://www.w3.org/2000/09/xmldsig#sha1"
+  settings.idp_cert_fingerprint_algorithm = "http://www.w3.org/2000/09/xmldsig#sha1"
   settings.name_identifier_format         = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
 
   # Optional for most SAML IdPs

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ def saml_settings
   settings.idp_sso_target_url             = "https://app.onelogin.com/trust/saml2/http-post/sso/#{OneLoginAppId}"
   settings.idp_slo_target_url             = "https://app.onelogin.com/trust/saml2/http-redirect/slo/#{OneLoginAppId}"
   settings.idp_cert_fingerprint           = OneLoginAppCertFingerPrint
+  settings.idp_cert_fingerprint_alg       = "http://www.w3.org/2000/09/xmldsig#sha1"
   settings.name_identifier_format         = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
 
   # Optional for most SAML IdPs

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -140,7 +140,7 @@ module OneLogin
         validate_response_state(soft) &&
         validate_conditions(soft)     &&
         validate_issuer(soft)         &&
-        document.validate_document(get_fingerprint, soft) &&
+        document.validate_document(get_fingerprint, soft, :fingerprint_alg => settings.idp_cert_fingerprint_alg) &&
         validate_success_status(soft)
       end
 
@@ -203,7 +203,8 @@ module OneLogin
       def get_fingerprint
         if settings.idp_cert
           cert = OpenSSL::X509::Certificate.new(settings.idp_cert)
-          Digest::SHA1.hexdigest(cert.to_der).upcase.scan(/../).join(":")
+          fingerprint_alg = XMLSecurity::BaseDocument.new.algorithm(settings.idp_cert_fingerprint_alg).new
+          fingerprint_alg.hexdigest(cert.to_der).upcase.scan(/../).join(":")
         else
           settings.idp_cert_fingerprint
         end

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -140,7 +140,7 @@ module OneLogin
         validate_response_state(soft) &&
         validate_conditions(soft)     &&
         validate_issuer(soft)         &&
-        document.validate_document(get_fingerprint, soft, :fingerprint_alg => settings.idp_cert_fingerprint_alg) &&
+        document.validate_document(get_fingerprint, soft, :fingerprint_alg => settings.idp_cert_fingerprint_algorithm) &&
         validate_success_status(soft)
       end
 
@@ -203,7 +203,7 @@ module OneLogin
       def get_fingerprint
         if settings.idp_cert
           cert = OpenSSL::X509::Certificate.new(settings.idp_cert)
-          fingerprint_alg = XMLSecurity::BaseDocument.new.algorithm(settings.idp_cert_fingerprint_alg).new
+          fingerprint_alg = XMLSecurity::BaseDocument.new.algorithm(settings.idp_cert_fingerprint_algorithm).new
           fingerprint_alg.hexdigest(cert.to_der).upcase.scan(/../).join(":")
         else
           settings.idp_cert_fingerprint

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -23,7 +23,7 @@ module OneLogin
       attr_accessor :idp_slo_target_url
       attr_accessor :idp_cert
       attr_accessor :idp_cert_fingerprint
-      attr_accessor :idp_cert_fingerprint_alg
+      attr_accessor :idp_cert_fingerprint_algorithm
       # SP Data
       attr_accessor :issuer
       attr_accessor :assertion_consumer_service_url
@@ -107,7 +107,7 @@ module OneLogin
       DEFAULTS = {
         :assertion_consumer_service_binding        => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST".freeze,
         :single_logout_service_binding             => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect".freeze,
-        :idp_cert_fingerprint_alg                  => XMLSecurity::Document::SHA1,
+        :idp_cert_fingerprint_algorithm            => XMLSecurity::Document::SHA1,
         :compress_request                          => true,
         :compress_response                         => true,
         :security                                  => {

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -23,6 +23,7 @@ module OneLogin
       attr_accessor :idp_slo_target_url
       attr_accessor :idp_cert
       attr_accessor :idp_cert_fingerprint
+      attr_accessor :idp_cert_fingerprint_alg
       # SP Data
       attr_accessor :issuer
       attr_accessor :assertion_consumer_service_url
@@ -106,6 +107,7 @@ module OneLogin
       DEFAULTS = {
         :assertion_consumer_service_binding        => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST".freeze,
         :single_logout_service_binding             => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect".freeze,
+        :idp_cert_fingerprint_alg                  => XMLSecurity::Document::SHA1,
         :compress_request                          => true,
         :compress_response                         => true,
         :security                                  => {

--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -182,7 +182,7 @@ module XMLSecurity
       extract_signed_element_id
     end
 
-    def validate_document(idp_cert_fingerprint, soft = true)
+    def validate_document(idp_cert_fingerprint, soft = true, options = {})
       # get cert from response
       cert_element = REXML::XPath.first(self, "//ds:X509Certificate", { "ds"=>DSIG })
       unless cert_element
@@ -192,13 +192,18 @@ module XMLSecurity
           raise OneLogin::RubySaml::ValidationError.new("Certificate element missing in response (ds:X509Certificate)")
         end
       end
-      base64_cert  = cert_element.text
-      cert_text    = Base64.decode64(base64_cert)
-      cert         = OpenSSL::X509::Certificate.new(cert_text)
+      base64_cert = cert_element.text
+      cert_text = Base64.decode64(base64_cert)
+      cert = OpenSSL::X509::Certificate.new(cert_text)
+
+      if options[:fingerprint_alg]
+        fingerprint_alg = XMLSecurity::BaseDocument.new.algorithm(options[:fingerprint_alg]).new
+      else
+        fingerprint_alg = OpenSSL::Digest::SHA1.new
+      end
+      fingerprint = fingerprint_alg.hexdigest(cert.to_der)
 
       # check cert matches registered idp cert
-      fingerprint = Digest::SHA1.hexdigest(cert.to_der)
-
       if fingerprint != idp_cert_fingerprint.gsub(/[^a-zA-Z0-9]/,"").downcase
         @errors << "Fingerprint mismatch"
         return soft ? false : (raise OneLogin::RubySaml::ValidationError.new("Fingerprint mismatch"))

--- a/test/xml_security_test.rb
+++ b/test/xml_security_test.rb
@@ -78,7 +78,45 @@ class XmlSecurityTest < Minitest::Test
     end
   end
 
-  describe "Algorithms" do
+  describe "Fingerprint Algorithms" do
+    let(:response_fingerprint_test) { OneLogin::RubySaml::Response.new(fixture(:adfs_response_sha1, false)) }
+
+    it "validate using SHA1" do
+      sha1_fingerprint = "F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72"
+      sha1_fingerprint_downcase = "f13c6b80905a030e6c913e5d15faddb016454872"
+
+      assert response_fingerprint_test.document.validate_document(sha1_fingerprint)
+      assert response_fingerprint_test.document.validate_document(sha1_fingerprint, true, :fingerprint_alg => XMLSecurity::Document::SHA1)
+
+      assert response_fingerprint_test.document.validate_document(sha1_fingerprint_downcase)
+      assert response_fingerprint_test.document.validate_document(sha1_fingerprint_downcase, true, :fingerprint_alg => XMLSecurity::Document::SHA1)
+      sha1_fingerprint_downcase
+    end
+
+    it "validate using SHA256" do
+      sha256_fingerprint = "C4:C6:BD:41:EC:AD:57:97:CE:7B:7D:80:06:C3:E4:30:53:29:02:0B:DD:2D:47:02:9E:BD:85:AD:93:02:45:21"
+
+      assert !response_fingerprint_test.document.validate_document(sha256_fingerprint)
+      assert response_fingerprint_test.document.validate_document(sha256_fingerprint, true, :fingerprint_alg => XMLSecurity::Document::SHA256)
+    end
+
+    it "validate using SHA384" do
+      sha384_fingerprint = "98:FE:17:90:31:E7:68:18:8A:65:4D:DA:F5:76:E2:09:97:BE:8B:E3:7E:AA:8D:63:64:7C:0C:38:23:9A:AC:A2:EC:CE:48:A6:74:4D:E0:4C:50:80:40:B4:8D:55:14:14"
+
+      assert !response_fingerprint_test.document.validate_document(sha384_fingerprint)
+      assert response_fingerprint_test.document.validate_document(sha384_fingerprint, true, :fingerprint_alg => XMLSecurity::Document::SHA384)
+    end
+
+    it "validate using SHA512" do
+      sha512_fingerprint = "5A:AE:BA:D0:BA:9D:1E:25:05:01:1E:1A:C9:E9:FF:DB:ED:FA:6E:F7:52:EB:45:49:BD:DB:06:D8:A3:7E:CC:63:3A:04:A2:DD:DF:EE:61:05:D9:58:95:2A:77:17:30:4B:EB:4A:9F:48:4A:44:1C:D0:9E:0B:1E:04:77:FD:A3:D2"
+
+      assert !response_fingerprint_test.document.validate_document(sha512_fingerprint)
+      assert response_fingerprint_test.document.validate_document(sha512_fingerprint, true, :fingerprint_alg => XMLSecurity::Document::SHA512)
+    end
+
+  end
+
+  describe "Signature Algorithms" do
     it "validate using SHA1" do
       @document = XMLSecurity::SignedDocument.new(fixture(:adfs_response_sha1, false))
       assert @document.validate_document("F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72")

--- a/test/xml_security_test.rb
+++ b/test/xml_security_test.rb
@@ -90,7 +90,6 @@ class XmlSecurityTest < Minitest::Test
 
       assert response_fingerprint_test.document.validate_document(sha1_fingerprint_downcase)
       assert response_fingerprint_test.document.validate_document(sha1_fingerprint_downcase, true, :fingerprint_alg => XMLSecurity::Document::SHA1)
-      sha1_fingerprint_downcase
     end
 
     it "validate using SHA256" do


### PR DESCRIPTION
Previously the toolkit assumed SHA1 algorithm as the algorithm used to generate the fingerprint.

I added the 'idp_cert_fingerprint_alg' parameter to the settings and now others ciphered fingerprint could be used.

Supported fingerprint algorithm:
- SHA1  "http://www.w3.org/2000/09/xmldsig#sha1"
- SHA256  "http://www.w3.org/2001/04/xmldsig-more#sha256"
- SHA384  "http://www.w3.org/2001/04/xmldsig-more#sha384"
- SHA512  "http://www.w3.org/2001/04/xmldsig-more#sha512"
