### PR TITLE
Force assertions to be signed.

### DIFF
--- a/lib/onelogin/ruby-saml/metadata.rb
+++ b/lib/onelogin/ruby-saml/metadata.rb
@@ -25,8 +25,8 @@ module OneLogin
         sp_sso = root.add_element "md:SPSSODescriptor", {
             "protocolSupportEnumeration" => "urn:oasis:names:tc:SAML:2.0:protocol",
             "AuthnRequestsSigned" => settings.security[:authn_requests_signed],
-            # However we would like assertions signed if idp_cert_fingerprint or idp_cert is set
-            "WantAssertionsSigned" => !!(settings.idp_cert_fingerprint || settings.idp_cert)
+            # However we always want assertions signed
+            "WantAssertionsSigned" => true
         }
         root.attributes["ID"] = "_" + UUID.new.generate
         if settings.issuer

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -27,7 +27,7 @@ class MetadataTest < Minitest::Test
 
       assert_equal "urn:oasis:names:tc:SAML:2.0:protocol", spsso_descriptor.attribute("protocolSupportEnumeration").value
       assert_equal "false", spsso_descriptor.attribute("AuthnRequestsSigned").value
-      assert_equal "false", spsso_descriptor.attribute("WantAssertionsSigned").value
+      assert_equal "true", spsso_descriptor.attribute("WantAssertionsSigned").value
 
       assert_equal "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress", REXML::XPath.first(xml_doc, "//md:NameIDFormat").text.strip
 
@@ -44,7 +44,7 @@ class MetadataTest < Minitest::Test
 
       assert_equal "urn:oasis:names:tc:SAML:2.0:protocol", spsso_descriptor.attribute("protocolSupportEnumeration").value
       assert_equal "false", spsso_descriptor.attribute("AuthnRequestsSigned").value
-      assert_equal "false", spsso_descriptor.attribute("WantAssertionsSigned").value
+      assert_equal "true", spsso_descriptor.attribute("WantAssertionsSigned").value
 
       assert_equal "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress", REXML::XPath.first(xml_doc, "//md:NameIDFormat").text.strip
 


### PR DESCRIPTION
address https://github.com/onelogin/ruby-saml/issues/220

When processing the response, the toolkit rejects anything that's unsigned. So the Metadata XML should always be WantAssertionsSigned="true"

But in https://github.com/onelogin/ruby-saml/blob/master/lib/onelogin/ruby-saml/metadata.rb#L29

WantAssertionsSigned is set to true only when settings.idp_cert_fingerprint or settings.idp_cert is set. In our workflow at least, user will most likely generates the metadata before setting the idp certs.
