### PR TITLE
ugly print metadata by default

### DIFF
--- a/lib/onelogin/ruby-saml/metadata.rb
+++ b/lib/onelogin/ruby-saml/metadata.rb
@@ -17,7 +17,7 @@ module OneLogin
       #                               (No pretty print if you gonna validate the signature)
       # @return [String] XML Metadata of the Service Provider
       #
-      def generate(settings, pretty_print=true)
+      def generate(settings, pretty_print=false)
         meta_doc = XMLSecurity::Document.new
         root = meta_doc.add_element "md:EntityDescriptor", {
             "xmlns:md" => "urn:oasis:names:tc:SAML:2.0:metadata"


### PR DESCRIPTION
As the method comment describes, SP metadata signatures cannot be
verified if they are pretty printed. For this reason, I contend that
pretty-print as a default is not sane. Certain IdPs will refuse to parse
signed metadata unless the signature can be verified (notably AD FS).

Changing the default will have no effect for users who explicitly set the value, and it should not have any adverse effect beyond impairing human readability of the raw xml and should only improve interoperability for those users who sign their metadata documents.