### PR TITLE
Fix metadata validation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ coverage
 rdoc
 pkg
 Gemfile.lock
+gemfiles/*.lock
 .idea/*
 lib/Lib.iml
 test/Test.iml

--- a/lib/onelogin/ruby-saml/metadata.rb
+++ b/lib/onelogin/ruby-saml/metadata.rb
@@ -19,9 +19,13 @@ module OneLogin
       #
       def generate(settings, pretty_print=false)
         meta_doc = XMLSecurity::Document.new
-        root = meta_doc.add_element "md:EntityDescriptor", {
+        namespaces = {
             "xmlns:md" => "urn:oasis:names:tc:SAML:2.0:metadata"
         }
+        if settings.attribute_consuming_service.configured?
+          namespaces["xmlns:saml"] = "urn:oasis:names:tc:SAML:2.0:assertion"
+        end
+        root = meta_doc.add_element "md:EntityDescriptor", namespaces
         sp_sso = root.add_element "md:SPSSODescriptor", {
             "protocolSupportEnumeration" => "urn:oasis:names:tc:SAML:2.0:protocol",
             "AuthnRequestsSigned" => settings.security[:authn_requests_signed],
@@ -36,9 +40,7 @@ module OneLogin
           sp_sso.add_element "md:SingleLogoutService", {
               "Binding" => settings.single_logout_service_binding,
               "Location" => settings.single_logout_service_url,
-              "ResponseLocation" => settings.single_logout_service_url,
-              "isDefault" => true,
-              "index" => 0
+              "ResponseLocation" => settings.single_logout_service_url
           }
         end
         if settings.name_identifier_format
@@ -87,7 +89,7 @@ module OneLogin
               "FriendlyName" => attribute[:friendly_name]
             }
             unless attribute[:attribute_value].nil?
-              sp_attr_val = sp_req_attr.add_element "md:AttributeValue"
+              sp_attr_val = sp_req_attr.add_element "saml:AttributeValue"
               sp_attr_val.text = attribute[:attribute_value]
             end
           end

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -51,8 +51,8 @@ class MetadataTest < Minitest::Test
       assert_equal "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect", sls.attribute("Binding").value
       assert_equal "https://foo.example/saml/sls", sls.attribute("Location").value
       assert_equal "https://foo.example/saml/sls", sls.attribute("ResponseLocation").value
-      assert sls.attribute("isDefault").value
-      assert_equal "0", sls.attribute("index").value
+      assert_nil sls.attribute("isDefault")
+      assert_nil sls.attribute("index")
 
       validate_xml!(xml_text, "saml-schema-metadata-2.0.xsd")
     end
@@ -137,7 +137,7 @@ class MetadataTest < Minitest::Test
         assert_equal "Name", req_attr.attribute("Name").value
         assert_equal "Name Format", req_attr.attribute("NameFormat").value
         assert_equal "Friendly Name", req_attr.attribute("FriendlyName").value
-        assert_equal "Attribute Value", REXML::XPath.first(xml_doc, "//md:AttributeValue").text.strip
+        assert_equal "Attribute Value", REXML::XPath.first(xml_doc, "//saml:AttributeValue").text.strip
 
         validate_xml!(xml_text, "saml-schema-metadata-2.0.xsd")
       end

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -33,6 +33,8 @@ class MetadataTest < Minitest::Test
 
       assert_equal "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST", acs.attribute("Binding").value
       assert_equal "https://foo.example/saml/consume", acs.attribute("Location").value      
+
+      validate_xml!(xml_text, "saml-schema-metadata-2.0.xsd")
     end
 
     it "generates Service Provider Metadata" do
@@ -51,6 +53,8 @@ class MetadataTest < Minitest::Test
       assert_equal "https://foo.example/saml/sls", sls.attribute("ResponseLocation").value
       assert sls.attribute("isDefault").value
       assert_equal "0", sls.attribute("index").value
+
+      validate_xml!(xml_text, "saml-schema-metadata-2.0.xsd")
     end
 
     it "generates Service Provider Metadata with single logout service" do
@@ -67,6 +71,8 @@ class MetadataTest < Minitest::Test
 
       assert_equal "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST", acs.attribute("Binding").value
       assert_equal "https://foo.example/saml/consume", acs.attribute("Location").value
+
+      validate_xml!(xml_text, "saml-schema-metadata-2.0.xsd")
     end
 
     describe "when auth requests are signed" do
@@ -95,6 +101,8 @@ class MetadataTest < Minitest::Test
         settings.security[:authn_requests_signed] = true
         assert_equal "true", spsso_descriptor.attribute("AuthnRequestsSigned").value
         assert_equal ruby_saml_cert.to_der, cert.to_der
+
+        validate_xml!(xml_text, "saml-schema-metadata-2.0.xsd")
       end
 
       it "generates Service Provider Metadata with X509Certificate for sign and encrypt" do
@@ -105,6 +113,8 @@ class MetadataTest < Minitest::Test
         assert_equal 2, cert_nodes.length
         assert_equal ruby_saml_cert.to_der, cert.to_der
         assert_equal cert_nodes[0].text, cert_nodes[1].text
+
+        validate_xml!(xml_text, "saml-schema-metadata-2.0.xsd")
       end
     end
 
@@ -128,6 +138,8 @@ class MetadataTest < Minitest::Test
         assert_equal "Name Format", req_attr.attribute("NameFormat").value
         assert_equal "Friendly Name", req_attr.attribute("FriendlyName").value
         assert_equal "Attribute Value", REXML::XPath.first(xml_doc, "//md:AttributeValue").text.strip
+
+        validate_xml!(xml_text, "saml-schema-metadata-2.0.xsd")
       end
 
       describe "#service_name" do
@@ -164,6 +176,8 @@ class MetadataTest < Minitest::Test
         assert_match %r[<ds:DigestMethod Algorithm='http://www.w3.org/2000/09/xmldsig#sha1'/>], xml_text
         signed_metadata = XMLSecurity::SignedDocument.new(xml_text)
         assert signed_metadata.validate_document(ruby_saml_cert_fingerprint, false)        
+
+        validate_xml!(xml_text, "saml-schema-metadata-2.0.xsd")
       end
 
       describe "when digest and signature methods are specified" do
@@ -180,6 +194,8 @@ class MetadataTest < Minitest::Test
           signed_metadata_2 = XMLSecurity::SignedDocument.new(xml_text)
 
           assert signed_metadata_2.validate_document(ruby_saml_cert_fingerprint, false)          
+
+          validate_xml!(xml_text, "saml-schema-metadata-2.0.xsd")
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,8 @@
 require 'simplecov'
 
 SimpleCov.start do
- add_filter "test/"
- add_filter "lib/onelogin/ruby-saml/logging.rb"
+  add_filter "test/"
+  add_filter "lib/onelogin/ruby-saml/logging.rb"
 end
 
 require 'rubygems'
@@ -215,5 +215,34 @@ class Minitest::Test
     zstream.finish
     zstream.close
     inflated
+  end
+
+  SCHEMA_DIR = File.expand_path(File.join(__FILE__, '../../lib/schemas'))
+
+  #
+  # validate an xml document against the given schema
+  #
+  def validate_xml!(document, schema)
+    Dir.chdir(SCHEMA_DIR) do
+      xsd = if schema.is_a? Nokogiri::XML::Schema
+              schema
+            else
+              Nokogiri::XML::Schema(File.read(schema))
+            end
+
+      xml = if document.is_a? Nokogiri::XML::Document
+              document
+            else
+              Nokogiri::XML(document) { |c| c.strict }
+            end
+
+      result = xsd.validate(xml)
+
+      if result.length != 0
+        raise "Schema validation failed! XSD validation errors: #{result.join(", ")}"
+      else
+        true
+      end
+    end
   end
 end


### PR DESCRIPTION
There are xml schema validation errors with the service provider metadata xml that is generated by `OneLogin::RubySaml::Metadata#generate`. The first is that `SingleLogoutService` isn't allowed to to have `isDefault` and `index` attributes. The other is that the `AttributeValue` element comes from the assertion schema, not the metadata schema. See the diff for the details.

I also added code that validates the xml produced by each test against the schema.