### PR TITLE
Separated the create_authentication_xml_doc in two methods

### DIFF
--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -87,6 +87,11 @@ module OneLogin
       # @return [String] The SAMLRequest String.
       #
       def create_authentication_xml_doc(settings)
+        document = create_xml_document(settings)
+        sign_document(document, settings)
+      end
+
+      def create_xml_document(settings)
         time = Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
 
         request_doc = XMLSecurity::Document.new
@@ -141,14 +146,18 @@ module OneLogin
           end
         end
 
+        request_doc
+      end
+
+      def sign_document(document, settings)
         # embed signature
         if settings.security[:authn_requests_signed] && settings.private_key && settings.certificate && settings.security[:embed_sign] 
           private_key = settings.get_sp_key
           cert = settings.get_sp_cert
-          request_doc.sign_document(private_key, cert, settings.security[:signature_method], settings.security[:digest_method])
+          document.sign_document(private_key, cert, settings.security[:signature_method], settings.security[:digest_method])
         end
 
-        request_doc
+        document
       end
 
     end


### PR DESCRIPTION
@pitbulk 
I ran in a problem that I can't find a good solution for.
I want to be able to add Scoping namespaces as per @tekt8tket 's  PR 

I do understand your need to keep the library simple 
I'm also thinking that the SAML standard is pretty big, and a library cannot cover all the usecases of SAML. 
Because of this, I find it imperative that the library should be open for extension.
The way Authrequest.create_authentication_xml_doc is now, with the signing of the document before it's returned, doesn't even allow easy monkey patching. 

So this is what I propose, a very simple split in the ````Authrequest.create_authentication_xml_doc```` between the creation and population of the document, and the signing, so you can hook your code between them.

What do you think?