### PR TITLE
Add no_destination option

### DIFF
--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -101,7 +101,7 @@ module OneLogin
         root.attributes['ID'] = uuid
         root.attributes['IssueInstant'] = time
         root.attributes['Version'] = "2.0"
-        root.attributes['Destination'] = settings.idp_sso_target_url unless settings.idp_sso_target_url.nil?
+        root.attributes['Destination'] = settings.idp_sso_target_url unless settings.no_destination || settings.idp_sso_target_url.nil?
         root.attributes['IsPassive'] = settings.passive unless settings.passive.nil?
         root.attributes['ProtocolBinding'] = settings.protocol_binding unless settings.protocol_binding.nil?
         root.attributes["AttributeConsumingServiceIndex"] = settings.attributes_index unless settings.attributes_index.nil?

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -48,6 +48,7 @@ module OneLogin
       attr_accessor :authn_context
       attr_accessor :authn_context_comparison
       attr_accessor :authn_context_decl_ref
+      attr_accessor :no_destination
       attr_reader :attribute_consuming_service
       # Work-flow
       attr_accessor :security

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -36,6 +36,22 @@ class RequestTest < Minitest::Test
       zstream.close
 
       assert_match /<samlp:AuthnRequest[^<]* Destination='http:\/\/example.com'/, inflated
+      assert_match /Destination/, inflated
+    end
+
+    it "respect the no_destination option" do
+      settings = OneLogin::RubySaml::Settings.new
+      settings.idp_sso_target_url = "http://example.com"
+      settings.no_destination = true
+      auth_url = OneLogin::RubySaml::Authrequest.new.create(settings)
+      payload  = CGI.unescape(auth_url.split("=").last)
+      decoded  = Base64.decode64(payload)
+
+      zstream  = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+      inflated = zstream.inflate(decoded)
+      zstream.finish
+      zstream.close
+      refute_match /Destination/, inflated
     end
 
     it "create the SAMLRequest URL parameter without deflating" do


### PR DESCRIPTION
According to the SAML specification at http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf the Destination attribute is optional:

```
Destination [Optional] A URI reference indicating the address to which this request has been sent. This is useful to prevent malicious forwarding of requests to unintended recipients, a protection that is required by some protocol bindings. If it is present, the actual recipient MUST check that the URI reference identifies the location at which the message was received. If it does not, the request MUST be discarded. Some protocol bindings may require the use of this attribute (see [SAMLBind]).
```

Some of our customers do not handle the Destination attribute correctly (the Identity Provider keeps redirecting to itself), therefore we had to make it optional.

This pull-request adds a ```no_destination``` option to the settings to remove the attribute from the SAML Request.
