### PR TITLE
use sudo: false for container infrastructure on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 rvm:
   - 1.8.7


### PR DESCRIPTION
The new Travis infrastructure runs all the tests in Docker, which should result in faster testing of PRs

http://docs.travis-ci.com/user/migrating-from-legacy/