### PR TITLE
Refactor error handling; allow multiple error messages with soft

### DIFF
--- a/lib/onelogin/ruby-saml/error_handling.rb
+++ b/lib/onelogin/ruby-saml/error_handling.rb
@@ -1,0 +1,27 @@
+require "onelogin/ruby-saml/validation_error"
+
+module OneLogin
+  module RubySaml
+    module ErrorHandling
+      attr_accessor :errors
+
+      # Append the cause to the errors array, and based on the value of soft, return false or raise
+      # an exception. soft_override is provided as a means of overriding the object's notion of
+      # soft for just this invocation.
+      def append_error(error_msg, soft_override = nil)
+        @errors << error_msg
+
+        unless soft_override.nil? ? soft : soft_override
+          raise ValidationError.new(error_msg)
+        end
+
+        false
+      end
+
+      # Reset the errors array
+      def reset_errors!
+        @errors = []
+      end
+    end
+  end
+end

--- a/lib/onelogin/ruby-saml/saml_message.rb
+++ b/lib/onelogin/ruby-saml/saml_message.rb
@@ -69,21 +69,13 @@ module OneLogin
           end
         rescue Exception => error
           return false if soft
-          validation_error("XML load failed: #{error.message}")
+          raise ValidationError.new("XML load failed: #{error.message}")
         end
 
         SamlMessage.schema.validate(xml).map do |error|
           return false if soft
-          validation_error("#{error.message}\n\n#{xml.to_s}")
+          raise ValidationError.new("#{error.message}\n\n#{xml.to_s}")
         end
-      end
-
-      # Raise a ValidationError with the provided message
-      # @param message [String] Message of the exception
-      # @raise [ValidationError]
-      #
-      def validation_error(message)
-        raise ValidationError.new(message)
       end
 
       private

--- a/lib/onelogin/ruby-saml/slo_logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutrequest.rb
@@ -11,12 +11,10 @@ module OneLogin
     # SAML2 Logout Request (SLO IdP initiated, Parser)
     #
     class SloLogoutrequest < SamlMessage
+      include ErrorHandling
 
       # OneLogin::RubySaml::Settings Toolkit settings
       attr_accessor :settings
-
-      # Array with the causes [Array of strings]
-      attr_accessor :errors
 
       attr_reader :document
       attr_reader :request
@@ -32,32 +30,20 @@ module OneLogin
       # @raise [ArgumentError] If Request is nil
       #
       def initialize(request, options = {})
-        @errors = []
         raise ArgumentError.new("Request cannot be nil") if request.nil?
-        @options  = options
 
+        @errors = []
+        @options = options
         @soft = true
-        if !options.empty? && !options[:settings].nil?
+        unless options[:settings].nil?
           @settings = options[:settings]
-          if !options[:settings].soft.nil? 
-            @soft = options[:settings].soft
+          unless @settings.soft.nil?
+            @soft = @settings.soft
           end
         end
 
         @request = decode_raw_saml(request)
         @document = REXML::Document.new(@request)
-      end
-
-      # Append the cause to the errors array, and based on the value of soft, return false or raise
-      # an exception
-      def append_error(error_msg)
-        @errors << error_msg
-        return soft ? false : validation_error(error_msg)
-      end
-
-      # Reset the errors array
-      def reset_errors!
-        @errors = []
       end
 
       # Validates the Logout Request with the default values (soft = true)
@@ -138,13 +124,15 @@ module OneLogin
       def validate
         reset_errors!
 
-        validate_request_state &&
-        validate_id &&
-        validate_version &&        
-        validate_structure &&
-        validate_not_on_or_after &&
-        validate_issuer &&
+        validate_request_state
+        validate_id
+        validate_version
+        validate_structure
+        validate_not_on_or_after
+        validate_issuer
         validate_signature
+
+        @errors.empty?
       end
 
       # Validates that the Logout Request contains an ID
@@ -213,7 +201,7 @@ module OneLogin
       # @raise [ValidationError] if soft == false and validation fails
       #
       def validate_issuer
-        return true if settings.idp_entity_id.nil? || issuer.nil?
+        return true if settings.nil? || settings.idp_entity_id.nil? || issuer.nil?
 
         unless URI.parse(issuer) == URI.parse(settings.idp_entity_id)
           return append_error("Doesn't match the issuer, expected: <#{settings.idp_entity_id}>, but was: <#{issuer}>")
@@ -230,7 +218,7 @@ module OneLogin
         return true if options.nil?
         return true unless options.has_key? :get_params
         return true unless options[:get_params].has_key? 'Signature'
-        return true if settings.nil? || settings.get_idp_cert.nil?
+        return true if settings.get_idp_cert.nil?
 
         query_string = OneLogin::RubySaml::Utils.build_query(
           :type        => 'SAMLRequest',

--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -29,7 +29,7 @@ require "openssl"
 require 'nokogiri'
 require "digest/sha1"
 require "digest/sha2"
-require "onelogin/ruby-saml/validation_error"
+require "onelogin/ruby-saml/error_handling"
 
 module XMLSecurity
 
@@ -179,9 +179,9 @@ module XMLSecurity
   end
 
   class SignedDocument < BaseDocument
+    include OneLogin::RubySaml::ErrorHandling
 
     attr_accessor :signed_element_id
-    attr_accessor :errors
 
     def initialize(response, errors = [])
       super(response)
@@ -200,15 +200,15 @@ module XMLSecurity
         { "ds"=>DSIG }
       )
       unless cert_element
-        if soft
-          return false
-        else
-          raise OneLogin::RubySaml::ValidationError.new("Certificate element missing in response (ds:X509Certificate)")
-        end
+        return append_error("Certificate element missing in response (ds:X509Certificate)", soft)
       end
       base64_cert = cert_element.text
       cert_text = Base64.decode64(base64_cert)
-      cert = OpenSSL::X509::Certificate.new(cert_text)
+      begin
+        cert = OpenSSL::X509::Certificate.new(cert_text)
+      rescue OpenSSL::X509::CertificateError => e
+        return append_error("Certificate Error", soft)
+      end
 
       if options[:fingerprint_alg]
         fingerprint_alg = XMLSecurity::BaseDocument.new.algorithm(options[:fingerprint_alg]).new
@@ -219,8 +219,7 @@ module XMLSecurity
 
       # check cert matches registered idp cert
       if fingerprint != idp_cert_fingerprint.gsub(/[^a-zA-Z0-9]/,"").downcase
-        @errors << "Fingerprint mismatch"
-        return soft ? false : (raise OneLogin::RubySaml::ValidationError.new("Fingerprint mismatch"))
+        return append_error("Fingerprint mismatch", soft)
       end
 
       validate_signature(base64_cert, soft)
@@ -298,8 +297,7 @@ module XMLSecurity
         digest_value = Base64.decode64(encoded_digest_value)
 
         unless digests_match?(hash, digest_value)
-          @errors << "Digest mismatch"
-          return soft ? false : (raise OneLogin::RubySaml::ValidationError.new("Digest mismatch"))
+          return append_error("Digest mismatch", soft)
         end
       end
 
@@ -324,8 +322,7 @@ module XMLSecurity
       signature_algorithm = algorithm(sig_alg_value)
 
       unless cert.public_key.verify(signature_algorithm.new, signature, canon_string)
-        @errors << "Key validation error"
-        return soft ? false : (raise OneLogin::RubySaml::ValidationError.new("Key validation error"))
+        return append_error("Key validation error", soft)
       end
 
       return true


### PR DESCRIPTION
When `soft` was introduced, it allowed business logic to examine failure without having to go through crazy `rescue` blocks. This was awesome.

However, what was not awesome was that debugging invalid responses in prod was tedious - if your server just output the `errors` on an object, you'd only see the first error that tripped the validator. Most of the time, there are other screwups too. This change allows errors to accumulate on an object when safe mode is set. It also centralizes some very repeated error handling code.

There are unfortunately a couple of rough spots where assumptions baked into test order right now - like nil derefs that aren't checked in later tests. I had to hack around a couple.

Also, `Response`'s use of `doc.validate_document` was out of date - `options` is now the third parameter, but the options hash was being passed as the value for `soft`.