### PR TITLE
Introduce sp_entity_id and use it to #validate_audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ We created a demo project for Rails4 that uses the latest version of this librar
 * Fork the repository
 * Make your feature addition or bug fix
 * Add tests for your new features. This is important so we don't break any features in a future version unintentionally.
-* Ensure all tests pass.
+* Ensure all tests pass when you run `bundle exec rake test`
 * Do not change rakefile, version, or history.
 * Open a pull request, following [this template](https://gist.github.com/Lordnibbler/11002759).
 

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -451,10 +451,10 @@ module OneLogin
       # @raise [ValidationError] if soft == false and validation fails
       #
       def validate_audience
-        return true if audiences.empty? || settings.issuer.nil? || settings.issuer.empty?
+        return true if audiences.empty? || settings.sp_entity_id.nil? || settings.sp_entity_id.empty?
 
-        unless audiences.include? settings.issuer
-          error_msg = "#{settings.issuer} is not a valid audience for this Response"
+        unless audiences.include? settings.sp_entity_id
+          error_msg = "#{settings.sp_entity_id} is not a valid audience for this Response"
           return append_error(error_msg)
         end
 

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -28,8 +28,9 @@ module OneLogin
       attr_accessor :idp_cert
       attr_accessor :idp_cert_fingerprint
       attr_accessor :idp_cert_fingerprint_algorithm
+      attr_accessor :issuer #refers to idp_entity_id
       # SP Data
-      attr_accessor :issuer
+      attr_accessor :sp_entity_id
       attr_accessor :assertion_consumer_service_url
       attr_accessor :assertion_consumer_service_binding
       attr_accessor :sp_name_qualifier

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -9,10 +9,10 @@ class SettingsTest < Minitest::Test
       @settings = OneLogin::RubySaml::Settings.new
     end
 
-    it "should provide getters and settings" do
+    it "should provide getters and setters" do
       accessors = [
         :idp_entity_id, :idp_sso_target_url, :idp_slo_target_url, :idp_cert, :idp_cert_fingerprint,
-        :issuer, :assertion_consumer_service_url, :assertion_consumer_service_binding,
+        :issuer, :sp_entity_id, :assertion_consumer_service_url, :assertion_consumer_service_binding,
         :single_logout_service_url, :single_logout_service_binding,
         :sp_name_qualifier, :name_identifier_format, :name_identifier_value,
         :sessionindex, :attributes_index, :passive, :force_authn,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -131,8 +131,8 @@ class Minitest::Test
     @unsigned_message_encrypted_unsigned_assertion ||= File.read(File.join(File.dirname(__FILE__), 'responses', 'unsigned_message_encrypted_unsigned_assertion.xml.base64'))    
   end
 
-  def signature_fingerprint_1
-    @signature_fingerprint1 ||= "C5:19:85:D9:47:F1:BE:57:08:20:25:05:08:46:EB:27:F6:CA:B7:83"
+  def response_valid_signed_fingerprint
+    "4B:68:C4:53:C7:D9:94:AA:D9:02:5C:99:D5:EF:CF:56:62:87:FE:8D"
   end
 
   # certificate used on response_with_undefined_recipient


### PR DESCRIPTION
## Status
READY

## Migrations
NO

## Description
The #validate_audience method matched the audience in the
SAML response with the settings#issuer, which is equal to
the IDP entity id. The audience should match the SP,
rather than the IDP.

This commit introduces #sp_entity_id as an option on settings and
has #validate_audience validate against it.

Also added a line to the README to make it easy to run all the specs.

## Related PRs
None

## Todos
- [x] Tests
- [x] Documentation


## Deploy Notes
None

## Steps to Test or Reproduce
See issue #283 


## Impacted Areas in Application
List general components of the application that this PR will affect:

*  OneLogin::RubySaml::Settings
*  OneLogin::RubySaml::Response

