### PR TITLE
Keep the extracted certificate when parsing IdP metadata

### DIFF
--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -118,8 +118,8 @@ module OneLogin
       def get_idp_cert
         return nil if idp_cert.nil? || idp_cert.empty?
 
-        formated_cert = OneLogin::RubySaml::Utils.format_cert(idp_cert)
-        OpenSSL::X509::Certificate.new(formated_cert)
+        formatted_cert = OneLogin::RubySaml::Utils.format_cert(idp_cert)
+        OpenSSL::X509::Certificate.new(formatted_cert)
       end
 
       # @return [OpenSSL::X509::Certificate|nil] Build the SP certificate from the settings (previously format it)
@@ -127,8 +127,8 @@ module OneLogin
       def get_sp_cert
         return nil if certificate.nil? || certificate.empty?
 
-        formated_cert = OneLogin::RubySaml::Utils.format_cert(certificate)
-        OpenSSL::X509::Certificate.new(formated_cert)
+        formatted_cert = OneLogin::RubySaml::Utils.format_cert(certificate)
+        OpenSSL::X509::Certificate.new(formatted_cert)
       end
 
       # @return [OpenSSL::PKey::RSA] Build the SP private from the settings (previously format it)


### PR DESCRIPTION
In our app we want to present the user with an option to use the federated metadata, or to type the certificate etc in themselves. Hopefully this will be useful for others in a similar situation.