### PR TITLE
IDP metadata parsing improved

### DIFF
--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -49,7 +49,7 @@ module OneLogin
           settings.idp_slo_target_binding ||= single_logout_service_binding(settings.idp_slo_target_parse_binding_priority)
           settings.idp_slo_target_url = single_logout_service_url(settings.idp_slo_target_binding)
           settings.idp_cert = certificate_base64
-          settings.idp_cert_fingerprint = fingerprint
+          settings.idp_cert_fingerprint = fingerprint(settings.idp_cert_fingerprint_algorithm)
         end
       end
 
@@ -198,11 +198,13 @@ module OneLogin
 
       # @return [String|nil] the SHA-1 fingerpint of the X509Certificate if it exists
       #
-      def fingerprint
+      def fingerprint(fingerprint_algorithm)
         @fingerprint ||= begin
           if certificate
             cert = OpenSSL::X509::Certificate.new(certificate)
-            Digest::SHA1.hexdigest(cert.to_der).upcase.scan(/../).join(":")
+
+            fingerprint_alg = XMLSecurity::BaseDocument.new.algorithm(fingerprint_algorithm).new
+            fingerprint_alg.hexdigest(cert.to_der).upcase.scan(/../).join(":")
           end
         end
       end

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -23,7 +23,11 @@ module OneLogin
 
       # IdP Data
       attr_accessor :idp_entity_id
+      attr_accessor :idp_sso_target_parse_binding_priority
+      attr_accessor :idp_sso_target_binding
       attr_accessor :idp_sso_target_url
+      attr_accessor :idp_slo_target_parse_binding_priority
+      attr_accessor :idp_slo_target_binding
       attr_accessor :idp_slo_target_url
       attr_accessor :idp_cert
       attr_accessor :idp_cert_fingerprint


### PR DESCRIPTION
* Parse SSO&SLO bindings with binding priority support
* Use settings.idp_cert_fingerprint_algorithm in idp_metadata_parser for fingerprint instead of SHA1

P.S. Should be fully backward compatible.