### PR TITLE
add Destination validation for ruby-saml/response

### DIFF
--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -415,6 +415,21 @@ class RubySamlTest < Minitest::Test
       end
     end
 
+    describe "#validate_destination" do
+      it "return true when the destination of the SAML Response matches the assertion consumer service url" do
+        response.settings = settings
+        assert response.send(:validate_destination)
+        assert_empty response.errors
+      end
+
+      it "return false when the destination of the SAML Response does not match the assertion consumer service url" do
+        response.settings = settings
+        response.settings.assertion_consumer_service_url = 'invalid_acs'
+        assert !response.send(:validate_destination)
+        assert_includes response.errors, "The response was received at #{response.destination} instead of #{response.settings.assertion_consumer_service_url}"
+      end
+    end
+
     describe "#validate_issuer" do
       it "return true when the issuer of the Message/Assertion matches the IdP entityId" do
         response_valid_signed.settings = settings


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
this change adds validation for `Destination` attribute which is optionally included in the SAML response.

- response method to return `Destination` attribute via `REXML`.
- response method to validate the destination against consumer service URL available in settings.
- unit tests.

note that @pitbulk originally implemented these changes in https://github.com/onelogin/ruby-saml/pull/197; however, this specific validation didn't make it to master branch (or >= 1.0.0). i merely duplicated his work and matched the new validation pattern (no `soft`) in `master`.

if accepted, this would fix https://github.com/onelogin/ruby-saml/issues/301.

## Related PRs

branch | PR
------ | ------
`response_validations`  | https://github.com/onelogin/ruby-saml/pull/197
`improve_validations` | https://github.com/onelogin/ruby-saml/pull/239

## Todos
- [x] Tests
- [x] Documentation – i don't think this is applicable; other validations aren't documented individually in `README`.

## Deploy Notes
no migrations or breaking changes; some IdPs may not send the right `Destination` due to configuration issues – since it's an _optional_ value, when provided, expectation is that it must be valid. to keep those integrations working, `#consume` action be tweaked to ignore validations for `Destination` attribute.

## Steps to Test or Reproduce
__N/A__

## Impacted Areas in Application
List general components of the application that this PR will affect:
* Response validation.