### PR TITLE
dont mutate document to fix lack of reference URI

### DIFF
--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -275,12 +275,6 @@ module XMLSecurity
       noko_sig_element = document.at_xpath('//ds:Signature', 'ds' => DSIG)
       noko_signed_info_element = noko_sig_element.at_xpath('./ds:SignedInfo', 'ds' => DSIG)
 
-      # Handle when no URI
-      noko_signed_info_reference_element_uri_attr = noko_signed_info_element.at_xpath('./ds:Reference', 'ds' => DSIG).attributes["URI"]
-      if (noko_signed_info_reference_element_uri_attr.value.empty?)
-        noko_signed_info_reference_element_uri_attr.value = "##{document.root.attribute('ID')}"
-      end
-
       canon_string = noko_signed_info_element.canonicalize(canon_algorithm)
       noko_sig_element.remove
 


### PR DESCRIPTION
previously this block of code would break signature validation for SAML responses that had `<Reference URI="">` in them.

additionally, the empty attribute case is already handled a few lines below anyway:

`hashed_element = uri.empty? ? document : document.at_xpath("//*[@ID=$uri]", nil, { 'uri' => uri[1..-1] })`

