### PR TITLE
ensure same validations are run whether collecting errors or not

### DIFF
--- a/lib/onelogin/ruby-saml/logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/logoutresponse.rb
@@ -110,22 +110,20 @@ module OneLogin
       def validate(collect_errors = false)
         reset_errors!
 
-        if collect_errors
-          valid_state?
-          validate_success_status
-          validate_structure
-          valid_in_response_to?
-          valid_issuer?
-          validate_signature
+        validations = [
+          :valid_state?,
+          :validate_success_status,
+          :validate_structure,
+          :valid_in_response_to?,
+          :valid_issuer?,
+          :validate_signature
+        ]
 
+        if collect_errors
+          validations.each { |validation| send(validation) }
           @errors.empty?
         else
-          valid_state? &&
-          validate_success_status &&
-          validate_structure &&
-          valid_in_response_to? &&
-          valid_issuer? &&
-          validate_signature
+          validations.all? { |validation| send(validation) }
         end
       end
 

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -290,41 +290,32 @@ module OneLogin
       #
       def validate(collect_errors = false)
         reset_errors!
+        return false unless validate_response_state
+
+        validations = [
+          :validate_response_state,
+          :validate_version,
+          :validate_id,
+          :validate_success_status,
+          :validate_num_assertion,
+          :validate_no_encrypted_attributes,
+          :validate_signed_elements,
+          :validate_structure,
+          :validate_in_response_to,
+          :validate_conditions,
+          :validate_audience,
+          :validate_destination,
+          :validate_issuer,
+          :validate_session_expiration,
+          :validate_subject_confirmation,
+          :validate_signature
+        ]
 
         if collect_errors
-          return false unless validate_response_state
-          validate_version
-          validate_id
-          validate_success_status
-          validate_num_assertion
-          validate_no_encrypted_attributes
-          validate_signed_elements
-          validate_structure
-          validate_in_response_to
-          validate_conditions
-          validate_audience
-          validate_issuer
-          validate_session_expiration
-          validate_subject_confirmation
-          validate_signature
+          validations.each { |validation| send(validation) }
           @errors.empty?
         else
-          validate_response_state &&
-          validate_version &&
-          validate_id &&
-          validate_success_status &&
-          validate_num_assertion &&
-          validate_no_encrypted_attributes &&
-          validate_signed_elements &&
-          validate_structure &&
-          validate_in_response_to &&
-          validate_conditions &&
-          validate_audience &&
-          validate_destination &&
-          validate_issuer &&
-          validate_session_expiration &&
-          validate_subject_confirmation &&
-          validate_signature
+          validations.all? { |validation| send(validation) }
         end
       end
 

--- a/lib/onelogin/ruby-saml/slo_logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutrequest.rb
@@ -126,24 +126,21 @@ module OneLogin
       def validate(collect_errors = false)
         reset_errors!
 
-        if collect_errors
-          validate_request_state
-          validate_id
-          validate_version
-          validate_structure
-          validate_not_on_or_after
-          validate_issuer
-          validate_signature
+        validations = [
+          :validate_request_state,
+          :validate_id,
+          :validate_version,
+          :validate_structure,
+          :validate_not_on_or_after,
+          :validate_issuer,
+          :validate_signature
+        ]
 
+        if collect_errors
+          validations.each { |validation| send(validation) }
           @errors.empty?
         else
-          validate_request_state &&
-          validate_id &&
-          validate_version &&
-          validate_structure &&
-          validate_not_on_or_after &&
-          validate_issuer &&
-          validate_signature
+          validations.all? { |validation| send(validation) }
         end
       end
 


### PR DESCRIPTION
`validate_destination` only occurred in one branch of the `validate` method. This change refactors to ensure the validations are defined only once and then called appropriately.