### PR TITLE
Added support for AssertionConsumerServiceIndex

### DIFF
--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -111,6 +111,9 @@ module OneLogin
         if settings.assertion_consumer_service_url != nil
           root.attributes["AssertionConsumerServiceURL"] = settings.assertion_consumer_service_url
         end
+        if settings.assertion_consumer_service_index != nil
+          root.attributes["AssertionConsumerServiceIndex"] = settings.assertion_consumer_service_index
+        end
         if settings.issuer != nil
           issuer = root.add_element "saml:Issuer"
           issuer.text = settings.issuer

--- a/lib/onelogin/ruby-saml/metadata.rb
+++ b/lib/onelogin/ruby-saml/metadata.rb
@@ -69,7 +69,7 @@ module OneLogin
               "Binding" => settings.assertion_consumer_service_binding,
               "Location" => settings.assertion_consumer_service_url,
               "isDefault" => true,
-              "index" => 0
+              "index" => settings.assertion_consumer_service_index
           }
         end
 

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -33,6 +33,7 @@ module OneLogin
       attr_accessor :issuer
       attr_accessor :assertion_consumer_service_url
       attr_accessor :assertion_consumer_service_binding
+      attr_accessor :assertion_consumer_service_index
       attr_accessor :sp_name_qualifier
       attr_accessor :name_identifier_format
       attr_accessor :name_identifier_value

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -15,6 +15,7 @@ class MetadataTest < Minitest::Test
       settings.issuer = "https://example.com"
       settings.name_identifier_format = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
       settings.assertion_consumer_service_url = "https://foo.example/saml/consume"
+      settings.assertion_consumer_service_index = "5"
     end
 
     it "generates Pretty Print Service Provider Metadata" do
@@ -33,6 +34,7 @@ class MetadataTest < Minitest::Test
 
       assert_equal "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST", acs.attribute("Binding").value
       assert_equal "https://foo.example/saml/consume", acs.attribute("Location").value      
+      assert_equal "5", acs.attribute("index").value
 
       assert validate_xml!(xml_text, "saml-schema-metadata-2.0.xsd")
     end

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -13,6 +13,7 @@ class SettingsTest < Minitest::Test
       accessors = [
         :idp_entity_id, :idp_sso_target_url, :idp_slo_target_url, :idp_cert, :idp_cert_fingerprint, :idp_cert_fingerprint_algorithm, :idp_attribute_names,
         :issuer, :assertion_consumer_service_url, :assertion_consumer_service_binding,
+        :assertion_consumer_service_index,
         :single_logout_service_url, :single_logout_service_binding,
         :sp_name_qualifier, :name_identifier_format, :name_identifier_value,
         :sessionindex, :attributes_index, :passive, :force_authn,
@@ -34,6 +35,7 @@ class SettingsTest < Minitest::Test
     it "create settings from hash" do
       config = {
           :assertion_consumer_service_url => "http://app.muda.no/sso",
+          :assertion_consumer_service_index => "5",
           :issuer => "http://muda.no",
           :sp_name_qualifier => "http://sso.muda.no",
           :idp_sso_target_url => "http://sso.muda.no/sso",


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
This pull request adds support for the `AssertionConsumerServiceIndex` to allow
for multiple development environments to work with an inflexible IdP.

## Todos
- I am unable to test this in production as I am using `ruby-saml` in a gem
which incorporate into many other apps. As Rails does not allow gem dependencies
to be local paths or Git/Github repositories, I need this to be merged to fully
test it. This is a very simple PR, however, and so its correctness can likely be
ascertained by inspection.


## Deploy Notes
N/A

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Orthogonal to current features.
