### PR TITLE
Explicitly parse as XML and fix setting of Nokogiri options.

### DIFF
--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -114,8 +114,8 @@ module XMLSecurity
       #<Object />
     #</Signature>
     def sign_document(private_key, certificate, signature_method = RSA_SHA1, digest_method = SHA1)
-      noko = Nokogiri.parse(self.to_s) do |options|
-        options = XMLSecurity::BaseDocument::NOKOGIRI_OPTIONS
+      noko = Nokogiri::XML(self.to_s) do |config|
+        config.options = XMLSecurity::BaseDocument::NOKOGIRI_OPTIONS
       end
 
       signature_element = REXML::Element.new("ds:Signature").add_namespace('ds', DSIG)
@@ -138,8 +138,8 @@ module XMLSecurity
       reference_element.add_element("ds:DigestValue").text = compute_digest(canon_doc, algorithm(digest_method_element))
 
       # add SignatureValue
-      noko_sig_element = Nokogiri.parse(signature_element.to_s) do |options|
-        options = XMLSecurity::BaseDocument::NOKOGIRI_OPTIONS
+      noko_sig_element = Nokogiri::XML(signature_element.to_s) do |config|
+        config.options = XMLSecurity::BaseDocument::NOKOGIRI_OPTIONS
       end
 
       noko_signed_info_element = noko_sig_element.at_xpath('//ds:Signature/ds:SignedInfo', 'ds' => DSIG)
@@ -242,8 +242,8 @@ module XMLSecurity
 
     def validate_signature(base64_cert, soft = true)
 
-      document = Nokogiri.parse(self.to_s) do |options|
-        options = XMLSecurity::BaseDocument::NOKOGIRI_OPTIONS
+      document = Nokogiri::XML(self.to_s) do |config|
+        config.options = XMLSecurity::BaseDocument::NOKOGIRI_OPTIONS
       end
 
       # create a rexml document


### PR DESCRIPTION
### Issue

`Nokogiri.parse` can return either a `Nokogiri::HTML::Document` or `Nokogiri::XML::Document`. This appears to be determined by a regular expression matcher: https://github.com/sparklemotion/nokogiri/blob/v1.5.11/lib/nokogiri.rb#L70

Because of this, if the characters `html` (case-insensitive) appears inside a tag in the document, Nokogiri will parse the document as HTML instead of XML, which breaks ruby-saml functionality. For instance, we hit this when one of our SAML responses happened to contain this in an ID attribute:

```
...5RwkhTMlTp1n...
```

In addition, while investigating the fix for this issue I noticed that the configuration options for the document did not appear to be set properly. It appears that these configuration options were introduced in #247 to address a security issue; I'm not sure I have enough context to assess this, but it might be that the original security issue was not fully addressed.

### Fix

Use `Nokogiri::XML` to ensure that the document is always parsed as XML. In addition, correctly set the `options` attribute in the XML document configuration.