### PR TITLE
Remove duplicate idp_cert_fingerprint assignment

### DIFF
--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -50,7 +50,6 @@ module OneLogin
           settings.idp_cert = certificate_base64
           settings.idp_cert_fingerprint = fingerprint(settings.idp_cert_fingerprint_algorithm)
           settings.idp_attribute_names = attribute_names
-          settings.idp_cert_fingerprint = fingerprint(settings.idp_cert_fingerprint_algorithm)
         end
       end
 


### PR DESCRIPTION
When https://github.com/onelogin/ruby-saml/commit/39116258fb745a44881cdc6cab568a8fda6e36d4 was merged in, it caused a duplicate call to `idp_cert_fingerprint=`. This removes the duplicate call.