### PR TITLE
Correct the usage of Mutex

### DIFF
--- a/lib/onelogin/ruby-saml/saml_message.rb
+++ b/lib/onelogin/ruby-saml/saml_message.rb
@@ -21,10 +21,12 @@ module OneLogin
 
       BASE64_FORMAT = %r(\A[A-Za-z0-9+/]{4}*[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=?\Z)
 
+      @@mutex = Mutex.new
+
       # @return [Nokogiri::XML::Schema] Gets the schema object of the SAML 2.0 Protocol schema
       #
       def self.schema
-        Mutex.new.synchronize do
+        @@mutex.synchronize do
           Dir.chdir(File.expand_path("../../../schemas", __FILE__)) do
             ::Nokogiri::XML::Schema(File.read("saml-schema-protocol-2.0.xsd"))
           end


### PR DESCRIPTION
`Mutex#synchronize` synchronizes the block by the receiver.
So should call `Mutex#synchronize` from the *same* receiver to synchronize.