### PR TITLE
Add Response#errors with an attr_reader

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -25,6 +25,7 @@ module OneLogin
 
       attr_reader :document
       attr_reader :decrypted_document
+      attr_reader :errors
       attr_reader :response
       attr_reader :options
 


### PR DESCRIPTION
Being able to access the list of errors on a response is sometimes convenient for debugging in development. This exposes the `@errors` variable through a public method.