### PR TITLE
Support multiple settings.auth_context

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ def saml_settings
 
   # Optional for most SAML IdPs
   settings.authn_context = "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"
+  # or as an array
+  settings.authn_context = [
+    "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
+    "urn:oasis:names:tc:SAML:2.0:ac:classes:Password"
+  ]
 
   # Optional bindings (defaults to Redirect for logout POST for acs)
   settings.assertion_consumer_service_binding = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"

--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -136,8 +136,11 @@ module OneLogin
           }
 
           if settings.authn_context != nil
-            class_ref = requested_context.add_element "saml:AuthnContextClassRef"
-            class_ref.text = settings.authn_context
+            authn_contexts = settings.authn_context.is_a?(Array) ? settings.authn_context : [settings.authn_context]
+            authn_contexts.each do |authn_context|
+              class_ref = requested_context.add_element "saml:AuthnContextClassRef"
+              class_ref.text = authn_context
+            end
           end
           # add saml:AuthnContextDeclRef element
           if settings.authn_context_decl_ref != nil

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -152,6 +152,13 @@ class RequestTest < Minitest::Test
       assert_match /<saml:AuthnContextClassRef>secure\/name\/password\/uri<\/saml:AuthnContextClassRef>/, auth_doc.to_s
     end
 
+    it "create multiple saml:AuthnContextClassRef elements correctly" do
+      settings.authn_context = ['foo', 'bar']
+      auth_doc = OneLogin::RubySaml::Authrequest.new.create_authentication_xml_doc(settings)
+      assert_match /<saml:AuthnContextClassRef>foo<\/saml:AuthnContextClassRef>/, auth_doc.to_s
+      assert_match /<saml:AuthnContextClassRef>bar<\/saml:AuthnContextClassRef>/, auth_doc.to_s
+    end
+
     it "create the saml:AuthnContextClassRef with comparison exact" do
       settings.authn_context = 'secure/name/password/uri'
       auth_doc = OneLogin::RubySaml::Authrequest.new.create_authentication_xml_doc(settings)

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -153,10 +153,10 @@ class RequestTest < Minitest::Test
     end
 
     it "create multiple saml:AuthnContextClassRef elements correctly" do
-      settings.authn_context = ['foo', 'bar']
+      settings.authn_context = ['secure/name/password/uri', 'secure/email/password/uri']
       auth_doc = OneLogin::RubySaml::Authrequest.new.create_authentication_xml_doc(settings)
-      assert_match /<saml:AuthnContextClassRef>foo<\/saml:AuthnContextClassRef>/, auth_doc.to_s
-      assert_match /<saml:AuthnContextClassRef>bar<\/saml:AuthnContextClassRef>/, auth_doc.to_s
+      assert_match /<saml:AuthnContextClassRef>secure\/name\/password\/uri<\/saml:AuthnContextClassRef>/, auth_doc.to_s
+      assert_match /<saml:AuthnContextClassRef>secure\/email\/password\/uri<\/saml:AuthnContextClassRef>/, auth_doc.to_s
     end
 
     it "create the saml:AuthnContextClassRef with comparison exact" do


### PR DESCRIPTION
**Why**: SAML supports multiple AuthnContextClassRef elements
in an Authn request.