### PR TITLE
Don't recreate the attributes object when there are no attributes

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -32,7 +32,7 @@ module OneLogin
 
       # Constructs the SAML Response. A Response Object that is an extension of the SamlMessage class.
       # @param response [String] A UUEncoded SAML response from the IdP.
-      # @param options  [Hash]   :settings to provide the OneLogin::RubySaml::Settings object 
+      # @param options  [Hash]   :settings to provide the OneLogin::RubySaml::Settings object
       #                          Or some options for the response validation process like skip the conditions validation
       #                          with the :skip_conditions, or allow a clock_drift when checking dates with :allowed_clock_drift
       #                          or :matches_request_id that will validate that the response matches the ID of the request,
@@ -115,33 +115,33 @@ module OneLogin
       #    attributes['name']
       #
       # @return [Attributes] OneLogin::RubySaml::Attributes enumerable collection.
-      #      
+      #
       def attributes
         @attr_statements ||= begin
           attributes = Attributes.new
 
           stmt_element = xpath_first_from_signed_assertion('/a:AttributeStatement')
-          return attributes if stmt_element.nil?
+          unless stmt_element.nil?
+            stmt_element.elements.each do |attr_element|
+              name = attr_element.attributes["Name"]
+              values = attr_element.elements.collect{|e|
+                if (e.elements.nil? || e.elements.size == 0)
+                  # SAMLCore requires that nil AttributeValues MUST contain xsi:nil XML attribute set to "true" or "1"
+                  # otherwise the value is to be regarded as empty.
+                  ["true", "1"].include?(e.attributes['xsi:nil']) ? nil : e.text.to_s
+                # explicitly support saml2:NameID with saml2:NameQualifier if supplied in attributes
+                # this is useful for allowing eduPersonTargetedId to be passed as an opaque identifier to use to
+                # identify the subject in an SP rather than email or other less opaque attributes
+                # NameQualifier, if present is prefixed with a "/" to the value
+                else
+                 REXML::XPath.match(e,'a:NameID', { "a" => ASSERTION }).collect{|n|
+                    (n.attributes['NameQualifier'] ? n.attributes['NameQualifier'] +"/" : '') + n.text.to_s
+                  }
+                end
+              }
 
-          stmt_element.elements.each do |attr_element|
-            name  = attr_element.attributes["Name"]
-            values = attr_element.elements.collect{|e|
-              if (e.elements.nil? || e.elements.size == 0)
-                # SAMLCore requires that nil AttributeValues MUST contain xsi:nil XML attribute set to "true" or "1"
-                # otherwise the value is to be regarded as empty.
-                ["true", "1"].include?(e.attributes['xsi:nil']) ? nil : e.text.to_s
-              # explicitly support saml2:NameID with saml2:NameQualifier if supplied in attributes
-              # this is useful for allowing eduPersonTargetedId to be passed as an opaque identifier to use to 
-              # identify the subject in an SP rather than email or other less opaque attributes
-              # NameQualifier, if present is prefixed with a "/" to the value
-              else 
-               REXML::XPath.match(e,'a:NameID', { "a" => ASSERTION }).collect{|n|
-                  (n.attributes['NameQualifier'] ? n.attributes['NameQualifier'] +"/" : '') + n.text.to_s
-                }
-              end
-            }
-
-            attributes.add(name, values.flatten)
+              attributes.add(name, values.flatten)
+            end
           end
 
           attributes
@@ -161,7 +161,7 @@ module OneLogin
 
       # Checks if the Status has the "Success" code
       # @return [Boolean] True if the StatusCode is Sucess
-      # 
+      #
       def success?
         status_code == "urn:oasis:names:tc:SAML:2.0:status:Success"
       end
@@ -326,7 +326,7 @@ module OneLogin
       #
       def validate_success_status
         return true if success?
-          
+
         error_msg = 'The status code of the Response was not Success'
         status_error_msg = OneLogin::RubySaml::Utils.status_error_msg(error_msg, status_code, status_message)
         append_error(status_error_msg)
@@ -334,7 +334,7 @@ module OneLogin
 
       # Validates the SAML Response against the specified schema.
       # @return [Boolean] True if the XML is valid, otherwise False if soft=True
-      # @raise [ValidationError] if soft == false and validation fails 
+      # @raise [ValidationError] if soft == false and validation fails
       #
       def validate_structure
         structure_error_msg = "Invalid SAML Response. Not match the saml-schema-protocol-2.0.xsd"
@@ -367,7 +367,7 @@ module OneLogin
         true
       end
 
-      # Validates that the SAML Response contains an ID 
+      # Validates that the SAML Response contains an ID
       # If fails, the error is added to the errors array.
       # @return [Boolean] True if the SAML Response contains an ID, otherwise returns False
       #
@@ -420,7 +420,7 @@ module OneLogin
       # @raise [ValidationError] if soft == false and validation fails
       #
       def validate_no_encrypted_attributes
-        nodes = xpath_from_signed_assertion("/a:AttributeStatement/a:EncryptedAttribute")        
+        nodes = xpath_from_signed_assertion("/a:AttributeStatement/a:EncryptedAttribute")
         if nodes && nodes.length > 0
           return append_error("There is an EncryptedAttribute in the Response and this SP not support them")
         end
@@ -599,7 +599,7 @@ module OneLogin
       end
 
       # Validates if exists valid SubjectConfirmation (If the response was initialized with the :allowed_clock_drift option,
-      # timimg validation are relaxed by the allowed_clock_drift value. If the response was initialized with the 
+      # timimg validation are relaxed by the allowed_clock_drift value. If the response was initialized with the
       # :skip_subject_confirmation option, this validation is skipped)
       # If fails, the error is added to the errors array
       # @return [Boolean] True if exists a valid SubjectConfirmation, otherwise False if soft=True
@@ -610,7 +610,7 @@ module OneLogin
         valid_subject_confirmation = false
 
         subject_confirmation_nodes = xpath_from_signed_assertion('/a:Subject/a:SubjectConfirmation')
-        
+
         now = Time.now.utc
         subject_confirmation_nodes.each do |subject_confirmation|
           if subject_confirmation.attributes.include? "Method" and subject_confirmation.attributes['Method'] != 'urn:oasis:names:tc:SAML:2.0:cm:bearer'
@@ -629,7 +629,7 @@ module OneLogin
           next if (attrs.include? "InResponseTo" and attrs['InResponseTo'] != in_response_to) ||
                   (attrs.include? "NotOnOrAfter" and (parse_time(confirmation_data_node, "NotOnOrAfter") + allowed_clock_drift) <= now) ||
                   (attrs.include? "NotBefore" and parse_time(confirmation_data_node, "NotBefore") > (now + allowed_clock_drift))
-          
+
           valid_subject_confirmation = true
           break
         end
@@ -680,7 +680,7 @@ module OneLogin
         opts[:cert] = settings.get_idp_cert
         fingerprint = settings.get_fingerprint
 
-        unless fingerprint && doc.validate_document(fingerprint, @soft, opts)          
+        unless fingerprint && doc.validate_document(fingerprint, @soft, opts)
           return append_error(error_msg)
         end
 

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -858,7 +858,11 @@ class RubySamlTest < Minitest::Test
       end
 
       it "not raise on responses without attributes" do
-        assert_equal OneLogin::RubySaml::Attributes.new, response_unsigned.attributes
+        assert_equal OneLogin::RubySaml::Attributes.new, response_without_attributes.attributes
+      end
+
+      it "keep same attributes instance on responses without attributes" do
+        assert_equal response_without_attributes.attributes.object_id, response_without_attributes.attributes.object_id
       end
 
       describe "#multiple values" do


### PR DESCRIPTION
Because of the early `return` this method was creating a new attributes
object each time it was called. When this is used in omniauth-saml
which sets `response.attributes[‘fingerprint’] =
options.idp_cert_fingerprint` the fingerprint is lost because the
object is discarded — this is problematic when you need to access the
fingerprint to see which IdP sent the SAML because the claims might not
apply to the entire entity-space; only those ‘owned’ by a particular
IdP.