### PR TITLE
Allows scheme and domain to match ignoring case

### DIFF
--- a/lib/onelogin/ruby-saml/logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/logoutresponse.rb
@@ -195,7 +195,7 @@ module OneLogin
       def valid_issuer?
         return true if settings.idp_entity_id.nil? || issuer.nil?
 
-        unless URI.parse(issuer) == URI.parse(settings.idp_entity_id)
+        unless OneLogin::RubySaml::Utils.uri_match?(issuer, settings.idp_entity_id)
           return append_error("Doesn't match the issuer, expected: <#{settings.idp_entity_id}>, but was: <#{issuer}>")
         end
         true

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -576,7 +576,7 @@ module OneLogin
 
         return true if settings.assertion_consumer_service_url.nil? || settings.assertion_consumer_service_url.empty?
 
-        unless OneLogin::RubySaml::Utils.uri_match?(destination, settings)
+        unless OneLogin::RubySaml::Utils.uri_match?(destination, settings.assertion_consumer_service_url)
           error_msg = "The response was received at #{destination} instead of #{settings.assertion_consumer_service_url}"
           return append_error(error_msg)
         end
@@ -670,7 +670,7 @@ module OneLogin
         issuers.uniq
 
         issuers.each do |issuer|
-          unless URI.parse(issuer) == URI.parse(settings.idp_entity_id)
+          unless OneLogin::RubySaml::Utils.uri_match?(issuer, settings.idp_entity_id)
             error_msg = "Doesn't match the issuer, expected: <#{settings.idp_entity_id}>, but was: <#{issuer}>"
             return append_error(error_msg)
           end

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -576,7 +576,7 @@ module OneLogin
 
         return true if settings.assertion_consumer_service_url.nil? || settings.assertion_consumer_service_url.empty?
 
-        unless uri_match?
+        unless OneLogin::RubySaml::Utils.uri_match?(destination, settings)
           error_msg = "The response was received at #{destination} instead of #{settings.assertion_consumer_service_url}"
           return append_error(error_msg)
         end
@@ -610,32 +610,6 @@ module OneLogin
         end
 
         true
-      end
-
-      # Compare the destination and the ACS url.  The scheme and the FQDN should be matched case insensitive, while
-      # the path should be case sensitive. If Rails can't parse out a scheme and a host, default to the
-      # original match.
-      # @return [Boolean]
-      def uri_match?
-        dest_uri = URI.parse(destination)
-        acs_uri = URI.parse(settings.assertion_consumer_service_url)
-
-        if dest_uri.scheme.nil? || acs_uri.scheme.nil? || dest_uri.host.nil? || acs_uri.host.nil?
-          raise URI::InvalidURIError
-        else
-          dest_uri.scheme.downcase == acs_uri.scheme.downcase &&
-            dest_uri.host.downcase == acs_uri.host.downcase &&
-            dest_uri.path == acs_uri.path &&
-            dest_uri.query == acs_uri.query
-        end
-      rescue URI::InvalidURIError
-        original_uri_match?
-      end
-
-      # If Rails' URI.parse can't match to valid URL, default back to the original matching service.
-      # @return [Boolean]
-      def original_uri_match?
-        destination == settings.assertion_consumer_service_url
       end
 
       # Validates the Conditions. (If the response was initialized with the :skip_conditions option, this validation is skipped,

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -576,7 +576,7 @@ module OneLogin
 
         return true if settings.assertion_consumer_service_url.nil? || settings.assertion_consumer_service_url.empty?
 
-        unless destination == settings.assertion_consumer_service_url
+        unless uri_match?
           error_msg = "The response was received at #{destination} instead of #{settings.assertion_consumer_service_url}"
           return append_error(error_msg)
         end
@@ -610,6 +610,32 @@ module OneLogin
         end
 
         true
+      end
+
+      # Compare the destination and the ACS url.  The scheme and the FQDN should be matched case insensitive, while
+      # the path should be case sensitive. If Rails can't parse out a scheme and a host, default to the
+      # original match.
+      # @return [Boolean]
+      def uri_match?
+        dest_uri = URI.parse(destination)
+        acs_uri = URI.parse(settings.assertion_consumer_service_url)
+
+        if dest_uri.scheme.nil? || acs_uri.scheme.nil? || dest_uri.host.nil? || acs_uri.host.nil?
+          raise URI::InvalidURIError
+        else
+          dest_uri.scheme.downcase == acs_uri.scheme.downcase &&
+            dest_uri.host.downcase == acs_uri.host.downcase &&
+            dest_uri.path == acs_uri.path &&
+            dest_uri.query == acs_uri.query
+        end
+      rescue URI::InvalidURIError
+        original_uri_match?
+      end
+
+      # If Rails' URI.parse can't match to valid URL, default back to the original matching service.
+      # @return [Boolean]
+      def original_uri_match?
+        destination == settings.assertion_consumer_service_url
       end
 
       # Validates the Conditions. (If the response was initialized with the :skip_conditions option, this validation is skipped,

--- a/lib/onelogin/ruby-saml/slo_logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutrequest.rb
@@ -212,7 +212,7 @@ module OneLogin
       def validate_issuer
         return true if settings.nil? || settings.idp_entity_id.nil? || issuer.nil?
 
-        unless URI.parse(issuer) == URI.parse(settings.idp_entity_id)
+        unless OneLogin::RubySaml::Utils.uri_match?(issuer, settings.idp_entity_id)
           return append_error("Doesn't match the issuer, expected: <#{settings.idp_entity_id}>, but was: <#{issuer}>")
         end
 

--- a/lib/onelogin/ruby-saml/utils.rb
+++ b/lib/onelogin/ruby-saml/utils.rb
@@ -184,13 +184,14 @@ module OneLogin
         RUBY_VERSION < '1.9' ? "_#{@@uuid_generator.generate}" : "_#{SecureRandom.uuid}"
       end
 
-      # Compare the destination and the ACS url.  The scheme and the FQDN should be matched case insensitive, while
-      # the path should be case sensitive. If Rails can't parse out a scheme and a host, default to the
-      # original match.
+      # Given two strings, attempt to match them as URIs using Rails' parse method.  If they can be parsed,
+      # then the fully-qualified domain name and the host should performa a case-insensitive match, per the
+      # RFC for URIs.  If Rails can not parse the string in to URL pieces, return a boolean match of the
+      # two strings.  This maintains the previous functionality.
       # @return [Boolean]
-      def self.uri_match?(destination, settings)
-        dest_uri = URI.parse(destination)
-        acs_uri = URI.parse(settings.assertion_consumer_service_url)
+      def self.uri_match?(destination_url, settings_url)
+        dest_uri = URI.parse(destination_url)
+        acs_uri = URI.parse(settings_url)
 
         if dest_uri.scheme.nil? || acs_uri.scheme.nil? || dest_uri.host.nil? || acs_uri.host.nil?
           raise URI::InvalidURIError
@@ -201,13 +202,13 @@ module OneLogin
             dest_uri.query == acs_uri.query
         end
       rescue URI::InvalidURIError
-        original_uri_match?(destination, settings)
+        original_uri_match?(destination_url, settings_url)
       end
 
       # If Rails' URI.parse can't match to valid URL, default back to the original matching service.
       # @return [Boolean]
-      def self.original_uri_match?(destination, settings)
-        destination == settings.assertion_consumer_service_url
+      def self.original_uri_match?(destination_url, settings_url)
+        destination_url == settings_url
       end
     end
   end

--- a/lib/onelogin/ruby-saml/utils.rb
+++ b/lib/onelogin/ruby-saml/utils.rb
@@ -183,6 +183,32 @@ module OneLogin
       def self.uuid
         RUBY_VERSION < '1.9' ? "_#{@@uuid_generator.generate}" : "_#{SecureRandom.uuid}"
       end
+
+      # Compare the destination and the ACS url.  The scheme and the FQDN should be matched case insensitive, while
+      # the path should be case sensitive. If Rails can't parse out a scheme and a host, default to the
+      # original match.
+      # @return [Boolean]
+      def self.uri_match?(destination, settings)
+        dest_uri = URI.parse(destination)
+        acs_uri = URI.parse(settings.assertion_consumer_service_url)
+
+        if dest_uri.scheme.nil? || acs_uri.scheme.nil? || dest_uri.host.nil? || acs_uri.host.nil?
+          raise URI::InvalidURIError
+        else
+          dest_uri.scheme.downcase == acs_uri.scheme.downcase &&
+            dest_uri.host.downcase == acs_uri.host.downcase &&
+            dest_uri.path == acs_uri.path &&
+            dest_uri.query == acs_uri.query
+        end
+      rescue URI::InvalidURIError
+        original_uri_match?(destination, settings)
+      end
+
+      # If Rails' URI.parse can't match to valid URL, default back to the original matching service.
+      # @return [Boolean]
+      def self.original_uri_match?(destination, settings)
+        destination == settings.assertion_consumer_service_url
+      end
     end
   end
 end

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -454,6 +454,34 @@ class RubySamlTest < Minitest::Test
         assert !response_empty_destination.send(:validate_destination)
         assert_includes response_empty_destination.errors, "The response has an empty Destination value"
       end
+
+      it "returns true on a case insensitive match on the domain" do
+        response_valid_signed_without_x509certificate.settings = settings
+        response_valid_signed_without_x509certificate.settings.assertion_consumer_service_url = 'http://APP.muDa.no/sso/consume'
+        assert response_valid_signed_without_x509certificate.send(:validate_destination)
+        assert_empty response_valid_signed_without_x509certificate.errors
+      end
+
+      it "returns true on a case insensitive match on the scheme" do
+        response_valid_signed_without_x509certificate.settings = settings
+        response_valid_signed_without_x509certificate.settings.assertion_consumer_service_url = 'HTTP://app.muda.no/sso/consume'
+        assert response_valid_signed_without_x509certificate.send(:validate_destination)
+        assert_empty response_valid_signed_without_x509certificate.errors
+      end
+
+      it "returns false on a case insenstive match on the path" do
+        response_valid_signed_without_x509certificate.settings = settings
+        response_valid_signed_without_x509certificate.settings.assertion_consumer_service_url = 'http://app.muda.no/SSO/consume'
+        assert !response_valid_signed_without_x509certificate.send(:validate_destination)
+        assert_includes response_valid_signed_without_x509certificate.errors, "The response was received at #{response_valid_signed_without_x509certificate.destination} instead of #{response_valid_signed_without_x509certificate.settings.assertion_consumer_service_url}"
+      end
+
+      it "returns true if it can't parse out a full URI." do
+        response_valid_signed_without_x509certificate.settings = settings
+        response_valid_signed_without_x509certificate.settings.assertion_consumer_service_url = 'presenter'
+        assert !response_valid_signed_without_x509certificate.send(:validate_destination)
+        assert_includes response_valid_signed_without_x509certificate.errors, "The response was received at #{response_valid_signed_without_x509certificate.destination} instead of #{response_valid_signed_without_x509certificate.settings.assertion_consumer_service_url}"
+      end
     end
 
     describe "#validate_issuer" do

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 
 class UtilsTest < Minitest::Test
   describe ".format_cert" do
@@ -152,6 +152,63 @@ class UtilsTest < Minitest::Test
 
       it "doesn't return the same value twice" do
         refute_equal OneLogin::RubySaml::Utils.uuid, OneLogin::RubySaml::Utils.uuid
+      end
+    end
+
+    describe 'uri_match' do
+      let(:settings) do
+        class MockSettings
+          attr_accessor :assertion_consumer_service_url
+        end
+        MockSettings.new
+      end
+
+      it 'matches two urls' do
+        destination = 'http://www.example.com/test?var=stuff'
+        settings.assertion_consumer_service_url = 'http://www.example.com/test?var=stuff'
+        assert OneLogin::RubySaml::Utils.uri_match?(destination, settings)
+      end
+
+      it 'fails to match two urls' do
+        destination = 'http://www.example.com/test?var=stuff'
+        settings.assertion_consumer_service_url = 'http://www.example.com/othertest?var=stuff'
+        assert !OneLogin::RubySaml::Utils.uri_match?(destination, settings)
+      end
+
+      it "matches two URLs if the scheme case doesn't match" do
+        destination = 'http://www.example.com/test?var=stuff'
+        settings.assertion_consumer_service_url = 'HTTP://www.example.com/test?var=stuff'
+        assert OneLogin::RubySaml::Utils.uri_match?(destination, settings)
+      end
+
+      it "matches two URLs if the host case doesn't match" do
+        destination = 'http://www.EXAMPLE.com/test?var=stuff'
+        settings.assertion_consumer_service_url = 'http://www.example.com/test?var=stuff'
+        assert OneLogin::RubySaml::Utils.uri_match?(destination, settings)
+      end
+
+      it "fails to match two URLs if the path case doesn't match" do
+        destination = 'http://www.example.com/TEST?var=stuff'
+        settings.assertion_consumer_service_url = 'http://www.example.com/test?var=stuff'
+        assert !OneLogin::RubySaml::Utils.uri_match?(destination, settings)
+      end
+
+      it "fails to match two URLs if the query case doesn't match" do
+        destination = 'http://www.example.com/test?var=stuff'
+        settings.assertion_consumer_service_url = 'http://www.example.com/test?var=STUFF'
+        assert !OneLogin::RubySaml::Utils.uri_match?(destination, settings)
+      end
+
+      it 'matches two non urls' do
+        destination = 'stuff'
+        settings.assertion_consumer_service_url = 'stuff'
+        assert OneLogin::RubySaml::Utils.uri_match?(destination, settings)
+      end
+
+      it "fails to match two non urls" do
+        destination = 'stuff'
+        settings.assertion_consumer_service_url = 'not stuff'
+        assert !OneLogin::RubySaml::Utils.uri_match?(destination, settings)
       end
     end
   end

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -156,58 +156,51 @@ class UtilsTest < Minitest::Test
     end
 
     describe 'uri_match' do
-      let(:settings) do
-        class MockSettings
-          attr_accessor :assertion_consumer_service_url
-        end
-        MockSettings.new
-      end
-
       it 'matches two urls' do
         destination = 'http://www.example.com/test?var=stuff'
-        settings.assertion_consumer_service_url = 'http://www.example.com/test?var=stuff'
+        settings = 'http://www.example.com/test?var=stuff'
         assert OneLogin::RubySaml::Utils.uri_match?(destination, settings)
       end
 
       it 'fails to match two urls' do
         destination = 'http://www.example.com/test?var=stuff'
-        settings.assertion_consumer_service_url = 'http://www.example.com/othertest?var=stuff'
+        settings = 'http://www.example.com/othertest?var=stuff'
         assert !OneLogin::RubySaml::Utils.uri_match?(destination, settings)
       end
 
       it "matches two URLs if the scheme case doesn't match" do
         destination = 'http://www.example.com/test?var=stuff'
-        settings.assertion_consumer_service_url = 'HTTP://www.example.com/test?var=stuff'
+        settings = 'HTTP://www.example.com/test?var=stuff'
         assert OneLogin::RubySaml::Utils.uri_match?(destination, settings)
       end
 
       it "matches two URLs if the host case doesn't match" do
         destination = 'http://www.EXAMPLE.com/test?var=stuff'
-        settings.assertion_consumer_service_url = 'http://www.example.com/test?var=stuff'
+        settings = 'http://www.example.com/test?var=stuff'
         assert OneLogin::RubySaml::Utils.uri_match?(destination, settings)
       end
 
       it "fails to match two URLs if the path case doesn't match" do
         destination = 'http://www.example.com/TEST?var=stuff'
-        settings.assertion_consumer_service_url = 'http://www.example.com/test?var=stuff'
+        settings = 'http://www.example.com/test?var=stuff'
         assert !OneLogin::RubySaml::Utils.uri_match?(destination, settings)
       end
 
       it "fails to match two URLs if the query case doesn't match" do
         destination = 'http://www.example.com/test?var=stuff'
-        settings.assertion_consumer_service_url = 'http://www.example.com/test?var=STUFF'
+        settings = 'http://www.example.com/test?var=STUFF'
         assert !OneLogin::RubySaml::Utils.uri_match?(destination, settings)
       end
 
       it 'matches two non urls' do
         destination = 'stuff'
-        settings.assertion_consumer_service_url = 'stuff'
+        settings = 'stuff'
         assert OneLogin::RubySaml::Utils.uri_match?(destination, settings)
       end
 
       it "fails to match two non urls" do
         destination = 'stuff'
-        settings.assertion_consumer_service_url = 'not stuff'
+        settings = 'not stuff'
         assert !OneLogin::RubySaml::Utils.uri_match?(destination, settings)
       end
     end


### PR DESCRIPTION
- Per RFC4343, the domain name portion of a URI should be considered case-insensitive.
- Per RFC3986, the scheme portion of a URI should be considered case-insenstive.
- Some SSO providers allow users to enter their own subdomain, which many may do with capital letters (such as in the case of an acronym).
- The destination match should take this in to consideration when matching the destination URI to the ACS URI, if these are proper URIs.
- The match should default to the original case when either of the values are not proper URIs.
