### PR TITLE
Allow for multiple RequestedAttribute AttributeValues

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,3 +614,5 @@ settings.attribute_consuming_service.configure do
   add_attribute :name => "Another Attribute", :name_format => "Name Format", :friendly_name => "Friendly Name", :attribute_value => "Attribute Value"
 end
 ```
+
+The `attribute_value` option additionally accepts an array of possible values.

--- a/lib/onelogin/ruby-saml/metadata.rb
+++ b/lib/onelogin/ruby-saml/metadata.rb
@@ -89,8 +89,10 @@ module OneLogin
               "FriendlyName" => attribute[:friendly_name]
             }
             unless attribute[:attribute_value].nil?
-              sp_attr_val = sp_req_attr.add_element "saml:AttributeValue"
-              sp_attr_val.text = attribute[:attribute_value]
+              Array(attribute[:attribute_value]).each do |value|
+                sp_attr_val = sp_req_attr.add_element "saml:AttributeValue"
+                sp_attr_val.text = value.to_str
+              end
             end
           end
         end


### PR DESCRIPTION
Closes #362 

This allows the service provider to specify multiple acceptable values for an attribute within an attribute consumer service.