### PR TITLE
[ENT-38] Add separate :want_assertions_encrypted flag to settings.security

### DIFF
--- a/lib/onelogin/ruby-saml/metadata.rb
+++ b/lib/onelogin/ruby-saml/metadata.rb
@@ -36,17 +36,23 @@ module OneLogin
         cert = settings.get_sp_cert
         if cert
           cert_text = Base64.encode64(cert.to_der).gsub("\n", '')
-          kd = sp_sso.add_element "md:KeyDescriptor", { "use" => "signing" }
-          ki = kd.add_element "ds:KeyInfo", {"xmlns:ds" => "http://www.w3.org/2000/09/xmldsig#"}
-          xd = ki.add_element "ds:X509Data"
-          xc = xd.add_element "ds:X509Certificate"
-          xc.text = cert_text
 
-          kd2 = sp_sso.add_element "md:KeyDescriptor", { "use" => "encryption" }
-          ki2 = kd2.add_element "ds:KeyInfo", {"xmlns:ds" => "http://www.w3.org/2000/09/xmldsig#"}
-          xd2 = ki2.add_element "ds:X509Data"
-          xc2 = xd2.add_element "ds:X509Certificate"
-          xc2.text = cert_text
+          if settings.security[:authn_requests_signed]
+            cert_text = Base64.encode64(cert.to_der).gsub("\n", '')
+            kd = sp_sso.add_element "md:KeyDescriptor", { "use" => "signing" }
+            ki = kd.add_element "ds:KeyInfo", {"xmlns:ds" => "http://www.w3.org/2000/09/xmldsig#"}
+            xd = ki.add_element "ds:X509Data"
+            xc = xd.add_element "ds:X509Certificate"
+            xc.text = cert_text
+          end
+
+          if settings.security[:want_assertions_encrypted]
+            kd2 = sp_sso.add_element "md:KeyDescriptor", { "use" => "encryption" }
+            ki2 = kd2.add_element "ds:KeyInfo", {"xmlns:ds" => "http://www.w3.org/2000/09/xmldsig#"}
+            xd2 = ki2.add_element "ds:X509Data"
+            xc2 = xd2.add_element "ds:X509Certificate"
+            xc2.text = cert_text
+          end
         end
 
         root.attributes["ID"] = OneLogin::RubySaml::Utils.uuid


### PR DESCRIPTION
As part of fixing ENT-38, I'd like to add a feature to OneLogin ruby_saml to have separate control for publishing signed authentication requests vs. requesting encrypted assertions. That will allow us to turn off encrypted assertions until we can fix the underlying bugs.