### PR TITLE
Validate serial number as string to work around libxml2 limitation

### DIFF
--- a/lib/schemas/xmldsig-core-schema.xsd
+++ b/lib/schemas/xmldsig-core-schema.xsd
@@ -188,7 +188,7 @@
 <complexType name="X509IssuerSerialType"> 
   <sequence> 
     <element name="X509IssuerName" type="string"/> 
-    <element name="X509SerialNumber" type="integer"/> 
+    <element name="X509SerialNumber" type="string"/>
   </sequence>
 </complexType>
 


### PR DESCRIPTION
Feel free to toss this pull request if you don't think it belongs in the main product; we can keep it in a private fork if necessary.

Based on discussion in https://github.com/benoist/xmldsig/issues/31 and https://mail.gnome.org/archives/xml/2008-March/thread.html#00044, I agree with the suggestion in https://github.com/onelogin/ruby-saml/compare/master...mokhan:x509serialnumber?expand=1 to hack the schema for certificate serial number validation in order to work around libxml2's arbitrary restriction on the size of XML Schema integers.

I have tested this against ADFS 2016 and our Ruby SP was able to process an encrypted assertion.