### PR TITLE
Remove redundant call in sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,10 +507,8 @@ def process_logout_response
     logger.error "The SAML Logout Response is invalid"
   else
     # Actually log out this session
-    if logout_response.success?
-      logger.info "Delete session for '#{session[:userid]}'"
-      delete_session
-    end
+    logger.info "Delete session for '#{session[:userid]}'"
+    delete_session
   end
 end
 


### PR DESCRIPTION
LogoutResponse sample code includes redundant call to `LogoutResponse.success?` despite the fact that `LogoutResponse.validate` is a superset of `LogoutResponse.success?`