### PR TITLE
Fix SLO request on IDP who need the correct value for NameQualifier and SPNameQualifier (Shibboleth v3).

### DIFF
--- a/lib/onelogin/ruby-saml/logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/logoutrequest.rb
@@ -102,7 +102,8 @@ module OneLogin
 
         nameid = root.add_element "saml:NameID"
         if settings.name_identifier_value
-          nameid.attributes['NameQualifier'] = settings.sp_name_qualifier if settings.sp_name_qualifier
+          nameid.attributes['NameQualifier'] = settings.idp_name_qualifier if settings.idp_name_qualifier
+          nameid.attributes['SPNameQualifier'] = settings.sp_name_qualifier if settings.sp_name_qualifier
           nameid.attributes['Format'] = settings.name_identifier_format if settings.name_identifier_format
           nameid.text = settings.name_identifier_value
         else

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -29,6 +29,7 @@ module OneLogin
       attr_accessor :idp_cert_fingerprint
       attr_accessor :idp_cert_fingerprint_algorithm
       attr_accessor :idp_attribute_names
+      attr_accessor :idp_name_qualifier
       # SP Data
       attr_accessor :issuer
       attr_accessor :assertion_consumer_service_url


### PR DESCRIPTION
Some IDPs validate and SLO request only if the correct values are set in NameID tag for attributes NameQualifier ans SPNameQualifier.
This code fix that.