### PR TITLE
Allow no Audience in schema

### DIFF
--- a/lib/schemas/saml-schema-assertion-2.0.xsd
+++ b/lib/schemas/saml-schema-assertion-2.0.xsd
@@ -142,7 +142,7 @@
         <complexContent>
             <extension base="saml:ConditionAbstractType">
                 <sequence>
-                    <element ref="saml:Audience" maxOccurs="unbounded"/>
+                    <element ref="saml:Audience" minOccurs="0" maxOccurs="unbounded"/>
                 </sequence>
             </extension>
         </complexContent>


### PR DESCRIPTION
I have an assertion with element `<saml:AudienceRestriction/>` which gives the following error:
```
OneLogin::RubySaml::ValidationError: Element '{urn:oasis:names:tc:SAML:2.0:assertion}AudienceRestriction': Missing child element(s). Expected is ( {urn:oasis:names:tc:SAML:2.0:assertion}Audience ).
```

According to section 2.5.1 of the [SAML spec](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf), this appears to be valid.

Modifying the schema fixes this.