### PR TITLE
add multiple session indexes to idp's logout request

### DIFF
--- a/lib/onelogin/ruby-saml/logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/logoutrequest.rb
@@ -113,8 +113,11 @@ module OneLogin
         end
 
         if settings.sessionindex
-          sessionindex = root.add_element "samlp:SessionIndex"
-          sessionindex.text = settings.sessionindex
+          session_indexes = settings.sessionindex.is_a?(Array)? settings.sessionindex : [settings.sessionindex]
+          session_indexes.each do|session_index|
+            session_index_element = root.add_element "samlp:SessionIndex"
+            session_index_element.text = session_index
+          end
         end
 
         # embed signature

--- a/test/logoutrequest_test.rb
+++ b/test/logoutrequest_test.rb
@@ -28,7 +28,7 @@ class RequestTest < Minitest::Test
       assert_match /&foo=bar$/, unauth_url
     end
 
-    it "set sessionindex" do
+    it "set single sessionindex" do
       settings.idp_slo_target_url = "http://example.com"
       sessionidx = OneLogin::RubySaml::Utils.uuid
       settings.sessionindex = sessionidx
@@ -39,6 +39,21 @@ class RequestTest < Minitest::Test
       assert_match /<samlp:SessionIndex/, inflated
       assert_match %r(#{sessionidx}</samlp:SessionIndex>), inflated
     end
+
+    it "set multiple sessionindexes" do
+      settings.idp_slo_target_url = "http://example.com"
+      sessionindexes = [OneLogin::RubySaml::Utils.uuid, OneLogin::RubySaml::Utils.uuid, OneLogin::RubySaml::Utils.uuid]
+      settings.sessionindex = sessionindexes
+
+      unauth_url = OneLogin::RubySaml::Logoutrequest.new.create(settings, { :nameid => "there" })
+      inflated = decode_saml_request_payload(unauth_url)
+
+      assert_match /<samlp:SessionIndex/, inflated
+      sessionindexes.each do |sessionindex|
+        assert_match %r(#{sessionindex}</samlp:SessionIndex>), inflated
+      end
+    end
+
 
     it "set name_identifier_value" do
       settings.name_identifier_format = "transient"


### PR DESCRIPTION
https://github.com/onelogin/ruby-saml/issues/384
Extended the IDP support to add a list of session indexes into its logout request. Please review my changes and let me know if there's any issue.

Thank you!