### PR TITLE
Attempt to detect binding for SSO and SLO

### DIFF
--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -142,7 +142,7 @@ module OneLogin
       # @return [String|nil] SingleSignOnService endpoint if exists
       #
       def single_signon_service_url(options = {})
-        binding = options[:sso_binding] || "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+        binding = options[:sso_binding] || single_signon_service_binding || "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
         node = REXML::XPath.first(
           document,
           "/md:EntityDescriptor/md:IDPSSODescriptor/md:SingleSignOnService[@Binding=\"#{binding}\"]/@Location",
@@ -172,7 +172,7 @@ module OneLogin
       # @return [String|nil] SingleLogoutService endpoint if exists
       #
       def single_logout_service_url(options = {})
-        binding = options[:slo_binding] || "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+        binding = options[:slo_binding] || single_logout_service_binding || "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
         node = REXML::XPath.first(
           document,
           "/md:EntityDescriptor/md:IDPSSODescriptor/md:SingleLogoutService[@Binding=\"#{binding}\"]/@Location",


### PR DESCRIPTION
We've got some metadata that looks like this...

```
<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://......"/>
```

The parser is trying to find

```
<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://......"/>
```

and failing because of the defaulting to `HTTP-Redirect`.

These changes allow the parser to find the correct SSO url because it will attempt to parse the binding instead of falling back to "HTTP-Redirect"