### PR TITLE
Implement IdpMetadataParser#parse_to_hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ And on 'signing' and 'encryption' arrays, add the different IdP x509 public cert
 The method above requires a little extra work to manually specify attributes about the IdP.  (And your SP application)  There's an easier method -- use a metadata exchange.  Metadata is just an XML file that defines the capabilities of both the IdP and the SP application.  It also contains the X.509 public
 key certificates which add to the trusted relationship.  The IdP administrator can also configure custom settings for an SP based on the metadata.
 
-Using ```idp_metadata_parser.parse_remote``` IdP metadata will be added to the settings withouth further ado.
+Using ```idp_metadata_parser.parse_remote``` IdP metadata will be added to the settings without further ado.
 
 ```ruby
 def saml_settings
@@ -300,9 +300,14 @@ def saml_settings
 end
 ```
 The following attributes are set:
+  * idp_entity_id
+  * name_identifier_format
   * idp_sso_target_url
   * idp_slo_target_url
-  * idp_cert_fingerprint
+  * idp_attribute_names
+  * idp_cert 
+  * idp_cert_fingerprint 
+  * idp_cert_multi
 
 ### Retrieve one Entity Descriptor when many exist in Metadata
 
@@ -318,6 +323,12 @@ IdpMetadataParser by its Entity Id value:
                 entity_id: "http//example.com/target/entity"
               )
 ```
+
+### Parsing Metadata into an Hash
+
+The `OneLogin::RubySaml::IdpMetadataParser` also provides the methods `#parse_to_hash` and `#parse_remote_to_hash`.
+Those return an Hash instead of a `Settings` object, which may be useful for configuring
+[omniauth-saml](https://github.com/omniauth/omniauth-saml), for instance.
 
 ## Retrieving Attributes
 

--- a/test/idp_metadata_parser_test.rb
+++ b/test/idp_metadata_parser_test.rb
@@ -95,6 +95,96 @@ class IdpMetadataParserTest < Minitest::Test
       assert_equal XMLSecurity::Document::RSA_SHA256, settings.security[:signature_method]
     end
 
+    it "merges results into given settings object" do
+      settings = OneLogin::RubySaml::Settings.new(:security => {
+        :digest_method => XMLSecurity::Document::SHA256,
+        :signature_method => XMLSecurity::Document::RSA_SHA256
+      })
+
+      OneLogin::RubySaml::IdpMetadataParser.new.parse(idp_metadata_descriptor, :settings => settings)
+
+      assert_equal "F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72", settings.idp_cert_fingerprint
+      assert_equal XMLSecurity::Document::SHA256, settings.security[:digest_method]
+      assert_equal XMLSecurity::Document::RSA_SHA256, settings.security[:signature_method]
+    end
+  end
+
+  describe "parsing an IdP descriptor file into an Hash" do
+    it "extract settings details from xml" do
+      idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
+
+      metadata = idp_metadata_parser.parse_to_hash(idp_metadata_descriptor)
+
+      assert_equal "https://hello.example.com/access/saml/idp.xml", metadata[:idp_entity_id]
+      assert_equal "https://hello.example.com/access/saml/login", metadata[:idp_sso_target_url]
+      assert_equal "F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72", metadata[:idp_cert_fingerprint]
+      assert_equal "https://hello.example.com/access/saml/logout", metadata[:idp_slo_target_url]
+      assert_equal "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified", metadata[:name_identifier_format]
+      assert_equal ["AuthToken", "SSOStartPage"], metadata[:idp_attribute_names]
+    end
+
+    it "extract certificate from md:KeyDescriptor[@use='signing']" do
+      idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
+      idp_metadata = idp_metadata_descriptor
+      metadata = idp_metadata_parser.parse_to_hash(idp_metadata)
+      assert_equal "F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72", metadata[:idp_cert_fingerprint]
+    end
+
+    it "extract certificate from md:KeyDescriptor[@use='encryption']" do
+      idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
+      idp_metadata = idp_metadata_descriptor
+      idp_metadata = idp_metadata.sub(/<md:KeyDescriptor use="signing">(.*?)<\/md:KeyDescriptor>/m, "")
+      parsed_metadata = idp_metadata_parser.parse_to_hash(idp_metadata)
+      assert_equal "F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72", parsed_metadata[:idp_cert_fingerprint]
+    end
+
+    it "extract certificate from md:KeyDescriptor" do
+      idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
+      idp_metadata = idp_metadata_descriptor
+      idp_metadata = idp_metadata.sub(/<md:KeyDescriptor use="signing">(.*?)<\/md:KeyDescriptor>/m, "")
+      idp_metadata = idp_metadata.sub('<md:KeyDescriptor use="encryption">', '<md:KeyDescriptor>')
+      parsed_metadata = idp_metadata_parser.parse_to_hash(idp_metadata)
+      assert_equal "F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72", parsed_metadata[:idp_cert_fingerprint]
+    end
+
+    it "extract SSO endpoint with no specific binding, it takes the first" do
+      idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
+      idp_metadata = idp_metadata_descriptor3
+      metadata = idp_metadata_parser.parse_to_hash(idp_metadata)
+      assert_equal "https://idp.example.com/idp/profile/Shibboleth/SSO", metadata[:idp_sso_target_url]
+    end
+
+    it "extract SSO endpoint with specific binding" do
+      idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
+      idp_metadata = idp_metadata_descriptor3
+      options = {}
+      options[:sso_binding] = ['urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST']
+      parsed_metadata = idp_metadata_parser.parse_to_hash(idp_metadata, options)
+      assert_equal "https://idp.example.com/idp/profile/SAML2/POST/SSO", parsed_metadata[:idp_sso_target_url]
+
+      options[:sso_binding] = ['urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect']
+      parsed_metadata = idp_metadata_parser.parse_to_hash(idp_metadata, options)
+      assert_equal "https://idp.example.com/idp/profile/SAML2/Redirect/SSO", parsed_metadata[:idp_sso_target_url]
+
+      options[:sso_binding] = ['invalid_binding', 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect']
+      parsed_metadata = idp_metadata_parser.parse_to_hash(idp_metadata, options)
+      assert_equal "https://idp.example.com/idp/profile/SAML2/Redirect/SSO", parsed_metadata[:idp_sso_target_url]
+    end
+
+    it "ignores a given :settings hash" do
+      idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
+      idp_metadata = idp_metadata_descriptor
+      parsed_metadata = idp_metadata_parser.parse_to_hash(idp_metadata, {
+        :settings => {
+          :security => {
+            :digest_method => XMLSecurity::Document::SHA256,
+            :signature_method => XMLSecurity::Document::RSA_SHA256
+          }
+        }
+      })
+      assert_equal "F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72", parsed_metadata[:idp_cert_fingerprint]
+      assert_nil parsed_metadata[:security]
+    end
   end
 
   describe "parsing an IdP descriptor file with multiple signing certs" do
@@ -147,6 +237,39 @@ class IdpMetadataParserTest < Minitest::Test
     it "accept self signed certificate if insturcted" do
       idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
       idp_metadata_parser.parse_remote(@url, false)
+
+      assert_equal OpenSSL::SSL::VERIFY_NONE, @http.verify_mode
+    end
+  end
+
+  describe "download and parse IdP descriptor file into an Hash" do
+    before do
+      mock_response = MockSuccessResponse.new
+      mock_response.body = idp_metadata_descriptor
+      @url = "https://example.com"
+      uri = URI(@url)
+
+      @http = Net::HTTP.new(uri.host, uri.port)
+      Net::HTTP.expects(:new).returns(@http)
+      @http.expects(:request).returns(mock_response)
+    end
+
+    it "extract settings from remote xml" do
+      idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
+      parsed_metadata = idp_metadata_parser.parse_remote_to_hash(@url)
+
+      assert_equal "https://hello.example.com/access/saml/idp.xml", parsed_metadata[:idp_entity_id]
+      assert_equal "https://hello.example.com/access/saml/login", parsed_metadata[:idp_sso_target_url]
+      assert_equal "F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72", parsed_metadata[:idp_cert_fingerprint]
+      assert_equal "https://hello.example.com/access/saml/logout", parsed_metadata[:idp_slo_target_url]
+      assert_equal "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified", parsed_metadata[:name_identifier_format]
+      assert_equal ["AuthToken", "SSOStartPage"], parsed_metadata[:idp_attribute_names]
+      assert_equal OpenSSL::SSL::VERIFY_PEER, @http.verify_mode
+    end
+
+    it "accept self signed certificate if insturcted" do
+      idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
+      idp_metadata_parser.parse_remote_to_hash(@url, false)
 
       assert_equal OpenSSL::SSL::VERIFY_NONE, @http.verify_mode
     end


### PR DESCRIPTION
…and IdpMetadataParser#parse_remote_to_hash.

Having the parsed metadata as Hash may be useful for configuring omniauth-saml, for instance. See omniauth/omniauth-saml#135