### PR TITLE
added SubjectConfirmation Recipient validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,11 +193,12 @@ def saml_settings
 end
 ```
 
-Some assertion validations can be skipped by passing parameters to `OneLogin::RubySaml::Response.new()`.  For example, you can skip the `Conditions` validation or the `SubjectConfirmation` validations by initializing the response with different options:
+Some assertion validations can be skipped by passing parameters to `OneLogin::RubySaml::Response.new()`.  For example, you can skip the `Conditions`, `Recipient`, or the `SubjectConfirmation` validations by initializing the response with different options:
 
 ```ruby
 response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], {skip_conditions: true}) # skips conditions
 response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], {skip_subject_confirmation: true}) # skips subject confirmation
+response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], {skip_recipient_check: true}) # doens't skip subject confirmation, but skips the recipient check which is a sub check of the subject_confirmation check
 ```
 
 All that's left is to wrap everything in a controller and reference it in the initialization and consumption URLs in OneLogin. A full controller example could look like this:

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -738,7 +738,7 @@ module OneLogin
           next if (attrs.include? "InResponseTo" and attrs['InResponseTo'] != in_response_to) ||
                   (attrs.include? "NotOnOrAfter" and (parse_time(confirmation_data_node, "NotOnOrAfter") + allowed_clock_drift) <= now) ||
                   (attrs.include? "NotBefore" and parse_time(confirmation_data_node, "NotBefore") > (now + allowed_clock_drift)) ||
-                  (attrs.include? "Recipient" and !options[:skip_recipient_check] and attrs['Recipient'] != settings&.assertion_consumer_service_url)
+                  (attrs.include? "Recipient" and !options[:skip_recipient_check] and settings and attrs['Recipient'] != settings.assertion_consumer_service_url)
 
           valid_subject_confirmation = true
           break

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -42,11 +42,6 @@ module OneLogin
 
         @errors = []
 
-        # skip recipient check by default for backwards compatibility
-        unless options.key?(:skip_recipient_check)
-          options[:skip_recipient_check] = true
-        end
-
         @options = options
         @soft = true
         unless options[:settings].nil?
@@ -743,7 +738,7 @@ module OneLogin
           next if (attrs.include? "InResponseTo" and attrs['InResponseTo'] != in_response_to) ||
                   (attrs.include? "NotOnOrAfter" and (parse_time(confirmation_data_node, "NotOnOrAfter") + allowed_clock_drift) <= now) ||
                   (attrs.include? "NotBefore" and parse_time(confirmation_data_node, "NotBefore") > (now + allowed_clock_drift)) ||
-                  (attrs.include? "Recipient" and !options[:skip_recipient_check] and attrs['Recipient'] != settings.assertion_consumer_service_url)
+                  (attrs.include? "Recipient" and !options[:skip_recipient_check] and attrs['Recipient'] != settings&.assertion_consumer_service_url)
 
           valid_subject_confirmation = true
           break

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -32,7 +32,7 @@ module OneLogin
 
       # Constructs the SAML Response. A Response Object that is an extension of the SamlMessage class.
       # @param response [String] A UUEncoded SAML response from the IdP.
-      # @param options  [Hash]   :settings to provide the OneLogin::RubySaml::Settings object 
+      # @param options  [Hash]   :settings to provide the OneLogin::RubySaml::Settings object
       #                          Or some options for the response validation process like skip the conditions validation
       #                          with the :skip_conditions, or allow a clock_drift when checking dates with :allowed_clock_drift
       #                          or :matches_request_id that will validate that the response matches the ID of the request,
@@ -189,7 +189,7 @@ module OneLogin
 
       # Checks if the Status has the "Success" code
       # @return [Boolean] True if the StatusCode is Sucess
-      # 
+      #
       def success?
         status_code == "urn:oasis:names:tc:SAML:2.0:status:Success"
       end
@@ -376,7 +376,7 @@ module OneLogin
       #
       def validate_success_status
         return true if success?
-          
+
         error_msg = 'The status code of the Response was not Success'
         status_error_msg = OneLogin::RubySaml::Utils.status_error_msg(error_msg, status_code, status_message)
         append_error(status_error_msg)
@@ -384,7 +384,7 @@ module OneLogin
 
       # Validates the SAML Response against the specified schema.
       # @return [Boolean] True if the XML is valid, otherwise False if soft=True
-      # @raise [ValidationError] if soft == false and validation fails 
+      # @raise [ValidationError] if soft == false and validation fails
       #
       def validate_structure
         structure_error_msg = "Invalid SAML Response. Not match the saml-schema-protocol-2.0.xsd"
@@ -417,7 +417,7 @@ module OneLogin
         true
       end
 
-      # Validates that the SAML Response contains an ID 
+      # Validates that the SAML Response contains an ID
       # If fails, the error is added to the errors array.
       # @return [Boolean] True if the SAML Response contains an ID, otherwise returns False
       #
@@ -706,7 +706,7 @@ module OneLogin
       end
 
       # Validates if exists valid SubjectConfirmation (If the response was initialized with the :allowed_clock_drift option,
-      # timimg validation are relaxed by the allowed_clock_drift value. If the response was initialized with the 
+      # timimg validation are relaxed by the allowed_clock_drift value. If the response was initialized with the
       # :skip_subject_confirmation option, this validation is skipped)
       # If fails, the error is added to the errors array
       # @return [Boolean] True if exists a valid SubjectConfirmation, otherwise False if soft=True
@@ -717,7 +717,7 @@ module OneLogin
         valid_subject_confirmation = false
 
         subject_confirmation_nodes = xpath_from_signed_assertion('/a:Subject/a:SubjectConfirmation')
-        
+
         now = Time.now.utc
         subject_confirmation_nodes.each do |subject_confirmation|
           if subject_confirmation.attributes.include? "Method" and subject_confirmation.attributes['Method'] != 'urn:oasis:names:tc:SAML:2.0:cm:bearer'
@@ -735,8 +735,9 @@ module OneLogin
           attrs = confirmation_data_node.attributes
           next if (attrs.include? "InResponseTo" and attrs['InResponseTo'] != in_response_to) ||
                   (attrs.include? "NotOnOrAfter" and (parse_time(confirmation_data_node, "NotOnOrAfter") + allowed_clock_drift) <= now) ||
-                  (attrs.include? "NotBefore" and parse_time(confirmation_data_node, "NotBefore") > (now + allowed_clock_drift))
-          
+                  (attrs.include? "NotBefore" and parse_time(confirmation_data_node, "NotBefore") > (now + allowed_clock_drift)) ||
+                  (attrs.include? "Recipient" and settings.assertion_consumer_service_url != nil and attrs['Recipient'] != settings.assertion_consumer_service_url)
+
           valid_subject_confirmation = true
           break
         end
@@ -808,7 +809,7 @@ module OneLogin
         opts[:cert] = settings.get_idp_cert
         fingerprint = settings.get_fingerprint
 
-        unless fingerprint && doc.validate_document(fingerprint, @soft, opts)          
+        unless fingerprint && doc.validate_document(fingerprint, @soft, opts)
           return append_error(error_msg)
         end
 

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -94,7 +94,7 @@ module OneLogin
       end
 
       # Setter for Single Logout Service Binding.
-      # 
+      #
       # (Currently we only support "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect")
       # @param url [String]
       #

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -676,6 +676,20 @@ class RubySamlTest < Minitest::Test
         assert_includes response_invalid_subjectconfirmation_noa.errors, "A valid SubjectConfirmation was not found on this Response"
       end
 
+      it "return true when valid subject confirmation recipient" do
+        response_valid_signed.settings = settings
+        response_valid_signed.settings.assertion_consumer_service_url= 'recipient'
+        assert response_valid_signed.send(:validate_subject_confirmation)
+        assert_empty response_valid_signed.errors
+      end
+
+      it "return false when valid subject confirmation recipient" do
+        response_valid_signed.settings = settings
+        response_valid_signed.settings.assertion_consumer_service_url = 'not-the-recipient'
+        assert !response_valid_signed.send(:validate_subject_confirmation)
+        assert_includes response_valid_signed.errors, "A valid SubjectConfirmation was not found on this Response"
+      end
+
       it "return true when the skip_subject_confirmation option is passed and the subject confirmation is valid" do
         opts = {}
         opts[:skip_subject_confirmation] = true


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
The SAML specificiation optionally specifies a Recipient field in the SubjectConfirmation element.  I believe this tag is not currently being validated.  See [here](https://www.google.com/search?q=saml+destination+vs+recipient&rlz=1C5CHFA_enUS721US721&oq=saml+destination+vs+recipient&aqs=chrome..69i57.4497j0j7&sourceid=chrome&ie=UTF-8).   I believe this correlates with settings.assertion_consumer_service_url, so I've added this check.

## Related PRs
NA

## Todos
- [X] Tests

## Deploy Notes
N/A

## Impacted Areas in Application
List general components of the application that this PR will affect:

* More accurate adherence to the SAML spec, additional security.
