### PR TITLE
[Documentation] [skip ci] Fixing a duplicated assignment of idp_sso_target_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ def saml_settings
 
   settings.assertion_consumer_service_url = "http://#{request.host}/saml/consume"
   settings.issuer                         = "http://#{request.host}/saml/metadata"
-  settings.idp_sso_target_url             = "https://app.onelogin.com/saml/metadata/#{OneLoginAppId}"
   settings.idp_entity_id                  = "https://app.onelogin.com/saml/metadata/#{OneLoginAppId}"
   settings.idp_sso_target_url             = "https://app.onelogin.com/trust/saml2/http-post/sso/#{OneLoginAppId}"
   settings.idp_slo_target_url             = "https://app.onelogin.com/trust/saml2/http-redirect/slo/#{OneLoginAppId}"


### PR DESCRIPTION
On the 'Initialization Phase' section the sample do a double assignment of`idp_sso_target_url`,
the one removed is kind of misleading since is pointing to metadata.

Apparently this was introduced on d37cdc7e7d6528bdfef4f6033361f20ec166c6a8.