### PR TITLE
validate_document_with_cert uses local cert when no cert in response

### DIFF
--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -260,9 +260,11 @@ module XMLSecurity
         # check saml response cert matches provided idp cert
         if idp_cert.to_pem != cert.to_pem
           return false
+        end
+      else
+        base64_cert = Base64.encode64(idp_cert.to_pem)
       end
-        validate_signature(base64_cert, true)
-      end
+      validate_signature(base64_cert, true)
     end
 
     def validate_signature(base64_cert, soft = true)

--- a/test/xml_security_test.rb
+++ b/test/xml_security_test.rb
@@ -388,5 +388,29 @@ class XmlSecurityTest < Minitest::Test
         end
       end
     end
+
+    describe '#validate_document_with_cert' do
+      describe 'with valid document ' do
+        describe 'when response has cert' do
+          let(:document_data) { read_response('response_with_signed_message_and_assertion.xml') }
+          let(:document) { OneLogin::RubySaml::Response.new(document_data).document }
+          let(:idp_cert) { OpenSSL::X509::Certificate.new(ruby_saml_cert_text) }
+          let(:fingerprint) { '4b68c453c7d994aad9025c99d5efcf566287fe8d' }
+
+          it 'is valid' do
+            assert document.validate_document_with_cert(idp_cert), 'Document should be valid'
+          end
+        end
+        
+        describe 'when response has no cert but you have local cert' do
+          let(:document) { OneLogin::RubySaml::Response.new(response_document_valid_signed_without_x509certificate).document }
+          let(:idp_cert) { OpenSSL::X509::Certificate.new(ruby_saml_cert_text) }
+
+          it 'is valid' do
+            assert document.validate_document_with_cert(idp_cert), 'Document should be valid'
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
I hit an issue when you have 2 certs signing and encryption and the cert is not included in the response.

After tracing it down, it appears that the validate_document_with_cert behaves differently to the validate_document method in that it won't fall back to the supplied cert when there was no cert included in the response.

I tried to write tests, but wasn't sure how to generate an signing/encryption pair of certs and wasn't sure I was allowed to use what my SP was using.