### PR TITLE
Allow responses to work with only an idp_cert_multi setting

### DIFF
--- a/lib/onelogin/ruby-saml/logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/logoutresponse.rb
@@ -168,7 +168,7 @@ module OneLogin
 
         return append_error("No issuer in settings of the logout response") if settings.issuer.nil?
 
-        if settings.idp_cert_fingerprint.nil? && settings.idp_cert.nil?
+        if settings.idp_cert_fingerprint.nil? && settings.idp_cert.nil? && settings.idp_cert_multi.nil?
           return append_error("No fingerprint or certificate on settings of the logout response")
         end
 

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -412,7 +412,7 @@ module OneLogin
 
         return append_error("No settings on response") if settings.nil?
 
-        if settings.idp_cert_fingerprint.nil? && settings.idp_cert.nil?
+        if settings.idp_cert_fingerprint.nil? && settings.idp_cert.nil? && settings.idp_cert_multi.nil?
           return append_error("No fingerprint or certificate on settings")
         end
 

--- a/test/logoutresponse_test.rb
+++ b/test/logoutresponse_test.rb
@@ -90,6 +90,7 @@ class RubySamlTest < Minitest::Test
         it "invalidate logout response when initiated with no idp cert or fingerprint" do
           settings.idp_cert_fingerprint = nil
           settings.idp_cert = nil
+          settings.idp_cert_multi = nil
           logoutresponse = OneLogin::RubySaml::Logoutresponse.new(valid_logout_response_document, settings)
           assert !logoutresponse.validate
           assert_includes logoutresponse.errors, "No fingerprint or certificate on settings of the logout response"

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -138,6 +138,7 @@ class RubySamlTest < Minitest::Test
         it "raise when No fingerprint or certificate on settings" do
           settings.idp_cert_fingerprint = nil
           settings.idp_cert = nil
+          settings.idp_cert_multi = nil
           response.settings = settings
           error_msg = "No fingerprint or certificate on settings"
           assert_raises(OneLogin::RubySaml::ValidationError, error_msg) do


### PR DESCRIPTION
When the settings only contain an idp_cert_multi fingerprint the
responses cannot be validated because it is wrongly assumes that the
certificate cannot be checked.

Include the idp_cert_multi setting in this check as well.

It may be helpful to move this check into settings, e.g. by providing a settings.has_idp_cert? method but I have not done so yet at this point.