### PR TITLE
fix failure when verifying validity of idp_cert_multi certificates

### DIFF
--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -335,7 +335,8 @@ module OneLogin
             )
           end
         else
-          parsed_metadata[:idp_cert_multi] = certificates
+          # symbolize keys of certificates and pass it on
+          parsed_metadata[:idp_cert_multi] = Hash[certificates.map { |k, v| [k.to_sym, v] }]
         end
       end
 

--- a/test/idp_metadata_parser_test.rb
+++ b/test/idp_metadata_parser_test.rb
@@ -202,10 +202,10 @@ class IdpMetadataParserTest < Minitest::Test
       assert_nil settings.idp_cert_fingerprint
       assert_nil settings.idp_cert
       assert_equal 2, settings.idp_cert_multi.size
-      assert settings.idp_cert_multi.key?("signing")
-      assert_equal 2, settings.idp_cert_multi["signing"].size
-      assert settings.idp_cert_multi.key?("encryption")
-      assert_equal 1, settings.idp_cert_multi["encryption"].size
+      assert settings.idp_cert_multi.key?(:signing)
+      assert_equal 2, settings.idp_cert_multi[:signing].size
+      assert settings.idp_cert_multi.key?(:encryption)
+      assert_equal 1, settings.idp_cert_multi[:encryption].size
     end
   end
 


### PR DESCRIPTION
I encountered an "Invalid Signature on SAML Response" error every time I tried SSO with my multi_sig IdP. It seems that there is some mixup happening with keys vs. strings as hash keys. This commit fixes the problem for me.