### PR TITLE
Allow space in Base64 string

### DIFF
--- a/lib/onelogin/ruby-saml/saml_message.rb
+++ b/lib/onelogin/ruby-saml/saml_message.rb
@@ -129,7 +129,7 @@ module OneLogin
       # @return [true, false] whether or not the string is base64 encoded
       #
       def base64_encoded?(string)
-        !!string.gsub(/[\r\n]|\\r|\\n/, "").match(BASE64_FORMAT)
+        !!string.gsub(/[\r\n]|\\r|\\n|\s/, "").match(BASE64_FORMAT)
       end
 
       # Inflate method


### PR DESCRIPTION
I have someone sending spaces in their SAMLResponse and Ruby properly decodes Base64 with spaces in it by ignoring them, so the check should ignore them too.