### PR TITLE
Expose NameID Format on SloLogoutrequest

### DIFF
--- a/lib/onelogin/ruby-saml/slo_logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutrequest.rb
@@ -66,6 +66,18 @@ module OneLogin
 
       alias_method :nameid, :name_id
 
+      # @return [String] Gets the NameID Format of the Logout Request.
+      #
+      def name_id_format
+        @name_id_node ||= REXML::XPath.first(document, "/p:LogoutRequest/a:NameID", { "p" => PROTOCOL, "a" => ASSERTION })
+        @name_id_format ||=
+          if @name_id_node && @name_id_node.attribute("Format")
+            @name_id_node.attribute("Format").value
+          end
+      end
+
+      alias_method :nameid_format, :name_id_format
+
       # @return [String|nil] Gets the ID attribute from the Logout Request. if exists.
       #
       def id

--- a/test/logout_requests/slo_request.xml
+++ b/test/logout_requests/slo_request.xml
@@ -1,4 +1,4 @@
 <samlp:LogoutRequest Version='2.0' ID='_c0348950-935b-0131-1060-782bcb56fcaa' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol' IssueInstant='2014-03-21T19:20:13'>
   <saml:Issuer xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>https://app.onelogin.com/saml/metadata/SOMEACCOUNT</saml:Issuer>
-  <saml:NameID xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>someone@example.org</saml:NameID>
+  <saml:NameID xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion' Format='urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'>someone@example.org</saml:NameID>
 </samlp:LogoutRequest>

--- a/test/logout_requests/slo_request_with_name_id_format.xml
+++ b/test/logout_requests/slo_request_with_name_id_format.xml
@@ -1,4 +1,4 @@
 <samlp:LogoutRequest Version='2.0' ID='_c0348950-935b-0131-1060-782bcb56fcaa' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol' IssueInstant='2014-03-21T19:20:13'>
   <saml:Issuer xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>https://app.onelogin.com/saml/metadata/SOMEACCOUNT</saml:Issuer>
-  <saml:NameID xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>someone@example.org</saml:NameID>
+  <saml:NameID xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion' Format='urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'>someone@example.org</saml:NameID>
 </samlp:LogoutRequest>

--- a/test/slo_logoutrequest_test.rb
+++ b/test/slo_logoutrequest_test.rb
@@ -91,6 +91,12 @@ class RubySamlTest < Minitest::Test
       end
     end
 
+    describe "#nameid_format" do
+      it "extract the format attribute of the name id element" do
+        assert_equal "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress", logout_request.nameid_format
+      end
+    end
+
     describe "#issuer" do
       it "return the issuer inside the logout request" do
         assert_equal "https://app.onelogin.com/saml/metadata/SOMEACCOUNT", logout_request.issuer

--- a/test/slo_logoutrequest_test.rb
+++ b/test/slo_logoutrequest_test.rb
@@ -92,6 +92,8 @@ class RubySamlTest < Minitest::Test
     end
 
     describe "#nameid_format" do
+      let(:logout_request) { OneLogin::RubySaml::SloLogoutrequest.new(logout_request_document_with_name_id_format) }
+
       it "extract the format attribute of the name id element" do
         assert_equal "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress", logout_request.nameid_format
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -183,6 +183,15 @@ class Minitest::Test
     @logout_request_document
   end
 
+  def logout_request_document_with_name_id_format
+    unless @logout_request_document_with_name_id_format
+      xml = read_logout_request("slo_request_with_name_id_format.xml")
+      deflated = Zlib::Deflate.deflate(xml, 9)[2..-5]
+      @logout_request_document_with_name_id_format = Base64.encode64(deflated)
+    end
+    @logout_request_document_with_name_id_format
+  end
+
   def logout_request_xml_with_session_index
     @logout_request_xml_with_session_index ||= File.read(File.join(File.dirname(__FILE__), 'logout_requests', 'slo_request_with_session_index.xml'))
   end


### PR DESCRIPTION
## Status
?? **READY/IN DEVELOPMENT/HOLD**

## Migrations
NO

## Description
Expose NameID Format on `SloLogoutrequest`.

This is equivalent to the `name_id_format` (`nameid_format`) methods on `Response` class. Clients are likely to need access to this (I did) for the same reasons as they need it on `Response`.
