### PR TITLE
Ensure `Rails` responds to `logger`

### DIFF
--- a/lib/onelogin/ruby-saml/logging.rb
+++ b/lib/onelogin/ruby-saml/logging.rb
@@ -7,7 +7,7 @@ module OneLogin
       DEFAULT_LOGGER = ::Logger.new(STDOUT)
 
       def self.logger
-        @logger || (defined?(::Rails) && Rails.logger) || DEFAULT_LOGGER
+        @logger || (defined?(::Rails) && Rails.respond_to?(:logger) && Rails.logger) || DEFAULT_LOGGER
       end
 
       def self.logger=(logger)


### PR DESCRIPTION
## Summary

* `Rails` module will not always respond to `logger`
* `OneLogin::RubySaml::Logging#logger` should check if `Rails` redponds to `logger` before calling it

## How to reproduce

```
$ cat Gemfile
source 'https://rubygems.org'
gem 'omniauth-saml'
gem 'kaminari-sinatra'

$ cat test.rb 
Bundler.require
logging = OneLogin::RubySaml::Logging
logging.logger

$ bundle install
$ bundle exec ruby test.rb
/usr/local/bundle/gems/ruby-saml-1.6.0/lib/onelogin/ruby-saml/logging.rb:10:in `logger': undefined method `logger' for Rails:Module (NoMethodError)
        from test.rb:3:in `<main>'
```