### PR TITLE
Updated invalid audience error, and tests to match.

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -597,7 +597,8 @@ module OneLogin
         return true if audiences.empty? || settings.issuer.nil? || settings.issuer.empty?
 
         unless audiences.include? settings.issuer
-          error_msg = "#{settings.issuer} is not a valid audience for this Response - Valid audiences: #{audiences.join(',')}"
+          s = audiences.count > 1 ? 's' : '';
+          error_msg = "Invalid Audience#{s}. The audience#{s} #{audiences.join(',')}, did not match the expected audience #{settings.issuer}"
           return append_error(error_msg)
         end
 


### PR DESCRIPTION
## Fixes:
https://github.com/onelogin/ruby-saml/issues/440


## Example
Given a SAML Assertion with the Audience value of "A", and an SP configuration requiring an audience of "B"

### Old message:

> "B is not a valid audience for this Response - Valid audiences: A"

or (for multiple)
> "B is not a valid audience for this Response - Valid audiences: A1, A2, A3"


### New message:

> Invalid Audience. The audience A, did not match the expected audience B

or (for multiple)

> Invalided Audiences. The audiences A1, A2, A3 did not match the expected audience B