### PR TITLE
OneLogin::RubySaml::Utils.element_text should normalize text before returning it

### DIFF
--- a/lib/onelogin/ruby-saml/utils.rb
+++ b/lib/onelogin/ruby-saml/utils.rb
@@ -286,7 +286,7 @@ module OneLogin
       # that there all children other than text nodes can be ignored (e.g. comments). If nil is
       # passed, nil will be returned.
       def self.element_text(element)
-        element.texts.join if element
+        element.texts.map(&:value).join if element
       end
     end
   end

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -230,6 +230,16 @@ class UtilsTest < Minitest::Test
         assert_equal 'element & text', OneLogin::RubySaml::Utils.element_text(element)
       end
 
+      it 'returns the CDATA element text' do
+        element = REXML::Document.new('<element><![CDATA[element & text]]></element>').elements.first
+        assert_equal 'element & text', OneLogin::RubySaml::Utils.element_text(element)
+      end
+
+      it 'returns the element text with newlines and additional whitespace' do
+        element = REXML::Document.new("<element>  element \n text  </element>").elements.first
+        assert_equal "  element \n text  ", OneLogin::RubySaml::Utils.element_text(element)
+      end
+
       it 'returns nil when element is nil' do
         assert_nil OneLogin::RubySaml::Utils.element_text(nil)
       end
@@ -238,6 +248,7 @@ class UtilsTest < Minitest::Test
         element = REXML::Document.new('<element></element>').elements.first
         assert_equal '', OneLogin::RubySaml::Utils.element_text(element)
       end
+
     end
   end
 end

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -229,6 +229,15 @@ class UtilsTest < Minitest::Test
         element = REXML::Document.new('<element>element &amp; text</element>').elements.first
         assert_equal 'element & text', OneLogin::RubySaml::Utils.element_text(element)
       end
+
+      it 'returns nil when element is nil' do
+        assert_nil OneLogin::RubySaml::Utils.element_text(nil)
+      end
+
+      it 'returns empty string when element has no text' do
+        element = REXML::Document.new('<element></element>').elements.first
+        assert_equal '', OneLogin::RubySaml::Utils.element_text(element)
+      end
     end
   end
 end

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -213,5 +213,22 @@ class UtilsTest < Minitest::Test
         assert !OneLogin::RubySaml::Utils.uri_match?(destination, settings)
       end
     end
+
+    describe 'element_text' do
+      it 'returns the element text' do
+        element = REXML::Document.new('<element>element text</element>').elements.first
+        assert_equal 'element text', OneLogin::RubySaml::Utils.element_text(element)
+      end
+
+      it 'returns all segments of the element text' do
+        element = REXML::Document.new('<element>element <!-- comment -->text</element>').elements.first
+        assert_equal 'element text', OneLogin::RubySaml::Utils.element_text(element)
+      end
+
+      it 'returns normalized element text' do
+        element = REXML::Document.new('<element>element &amp; text</element>').elements.first
+        assert_equal 'element & text', OneLogin::RubySaml::Utils.element_text(element)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #445.