### PR TITLE
add ability to skip authnstatement validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,9 +235,10 @@ def saml_settings
 end
 ```
 
-Some assertion validations can be skipped by passing parameters to `OneLogin::RubySaml::Response.new()`.  For example, you can skip the `Conditions`, `Recipient`, or the `SubjectConfirmation` validations by initializing the response with different options:
+Some assertion validations can be skipped by passing parameters to `OneLogin::RubySaml::Response.new()`.  For example, you can skip the `AuthnStatement`, `Conditions`, `Recipient`, or the `SubjectConfirmation` validations by initializing the response with different options:
 
 ```ruby
+response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], {skip_authnstatement: true}) # skips AuthnStatement
 response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], {skip_conditions: true}) # skips conditions
 response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], {skip_subject_confirmation: true}) # skips subject confirmation
 response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], {skip_recipient_check: true}) # doens't skip subject confirmation, but skips the recipient check which is a sub check of the subject_confirmation check

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -633,6 +633,8 @@ module OneLogin
       # @return [Boolean] True if there is a authnstatement element and is unique
       #
       def validate_one_authnstatement
+        return true if options[:skip_authnstatement]
+        
         authnstatement_nodes = xpath_from_signed_assertion('/a:AuthnStatement')
         unless authnstatement_nodes.size == 1
           error_msg = "The Assertion must include one AuthnStatement element"

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -24,6 +24,7 @@ class RubySamlTest < Minitest::Test
     let(:response_multi_assertion) { OneLogin::RubySaml::Response.new(read_invalid_response("multiple_assertions.xml.base64")) }
     let(:response_no_conditions) { OneLogin::RubySaml::Response.new(read_invalid_response("no_conditions.xml.base64")) }
     let(:response_no_authnstatement) { OneLogin::RubySaml::Response.new(read_invalid_response("no_authnstatement.xml.base64")) }
+    let(:response_no_authnstatement_with_skip) { OneLogin::RubySaml::Response.new(read_invalid_response("no_authnstatement.xml.base64"), {:skip_authnstatement => true}) }
     let(:response_empty_destination) { OneLogin::RubySaml::Response.new(read_invalid_response("empty_destination.xml.base64")) }
     let(:response_empty_destination_with_skip) { OneLogin::RubySaml::Response.new(read_invalid_response("empty_destination.xml.base64"), {:skip_destination => true}) }
     let(:response_no_status) { OneLogin::RubySaml::Response.new(read_invalid_response("no_status.xml.base64")) }
@@ -996,6 +997,12 @@ class RubySamlTest < Minitest::Test
       it "return true when one authnstatement element" do
         response.soft = true
         assert response.send(:validate_one_authnstatement)
+      end
+
+      it "return true when SAML Response is empty but skip_authstatement option is used" do
+        response_no_authnstatement_with_skip.soft = true
+        assert response_no_authnstatement_with_skip.send(:validate_one_authnstatement)
+        assert_empty response_empty_destination_with_skip.errors
       end
     end
 


### PR DESCRIPTION
Our company is using this gem to interact with another company, and they do not provide an `AuthnStatement` in their payload. We need to validate their payload regardless of this fact.

We have added the ability to optionally skip the `AuthnStatement` validation to accomplish this.

* the validation will still happen by default
* if you pass `{skip_authnstatement: true}` to the options, the validation will be skipped
* updates documentation to reflect this change