### PR TITLE
Fix behavior of skip_conditions flag on Response

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -615,10 +615,13 @@ module OneLogin
       end
 
       # Checks that the samlp:Response/saml:Assertion/saml:Conditions element exists and is unique.
+      # (If the response was initialized with the :skip_conditions option, this validation is skipped)
       # If fails, the error is added to the errors array
       # @return [Boolean] True if there is a conditions element and is unique
       #
       def validate_one_conditions
+        return true if options[:skip_conditions]
+
         conditions_nodes = xpath_from_signed_assertion('/a:Conditions')
         unless conditions_nodes.size == 1
           error_msg = "The Assertion must include one Conditions element"
@@ -634,7 +637,7 @@ module OneLogin
       #
       def validate_one_authnstatement
         return true if options[:skip_authnstatement]
-        
+
         authnstatement_nodes = xpath_from_signed_assertion('/a:AuthnStatement')
         unless authnstatement_nodes.size == 1
           error_msg = "The Assertion must include one AuthnStatement element"

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -23,6 +23,7 @@ class RubySamlTest < Minitest::Test
     let(:response_no_version) { OneLogin::RubySaml::Response.new(read_invalid_response("no_saml2.xml.base64")) }
     let(:response_multi_assertion) { OneLogin::RubySaml::Response.new(read_invalid_response("multiple_assertions.xml.base64")) }
     let(:response_no_conditions) { OneLogin::RubySaml::Response.new(read_invalid_response("no_conditions.xml.base64")) }
+    let(:response_no_conditions_with_skip) { OneLogin::RubySaml::Response.new(read_invalid_response("no_conditions.xml.base64"), { :skip_conditions => true }) }
     let(:response_no_authnstatement) { OneLogin::RubySaml::Response.new(read_invalid_response("no_authnstatement.xml.base64")) }
     let(:response_no_authnstatement_with_skip) { OneLogin::RubySaml::Response.new(read_invalid_response("no_authnstatement.xml.base64"), {:skip_authnstatement => true}) }
     let(:response_empty_destination) { OneLogin::RubySaml::Response.new(read_invalid_response("empty_destination.xml.base64")) }
@@ -983,6 +984,11 @@ class RubySamlTest < Minitest::Test
       it "return true when one conditions element" do
         response.soft = true
         assert response.send(:validate_one_conditions)
+      end
+
+      it "return true when no conditions are present and skip_conditions is true" do
+        response_no_conditions_with_skip.soft = true
+        assert response_no_conditions_with_skip.send(:validate_one_conditions)
       end
     end
 


### PR DESCRIPTION
Ensure the skip_conditions flag allows a Response with no Conditions
elements to be valid. Fixes #451