### PR TITLE
Raise a more descriptive exception if idp_sso_target_url is missing

### DIFF
--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -36,6 +36,7 @@ module OneLogin
         params.each_pair do |key, value|
           request_params << "&#{key.to_s}=#{CGI.escape(value.to_s)}"
         end
+        raise "Invalid settings, idp_sso_target_url is not set!" if settings.idp_sso_target_url.nil?
         @login_url = settings.idp_sso_target_url + request_params
       end
 

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -129,6 +129,19 @@ class RequestTest < Minitest::Test
       assert_match /&hello=$/, auth_url
     end
 
+    describe "when the target url is not set" do
+      before do
+        settings.idp_sso_target_url = nil
+      end
+
+      it "raises an error with a descriptive message" do
+        err = assert_raises RuntimeError do
+          OneLogin::RubySaml::Authrequest.new.create(settings)
+        end
+        assert_match /idp_sso_target_url is not set/, err.message
+      end
+    end
+
     describe "when the target url doesn't contain a query string" do
       it "create the SAMLRequest parameter correctly" do
 


### PR DESCRIPTION
If idp_sso_target_url is missing, creating the authrequest fails currently with:
```NoMethodError (undefined method `+' for nil:NilClass)```
This is not very descriptive, so this pull request makes the exception message more helpful.

The motivation/need for this is that typically services handle the saml settings in some kind of dynamic way. If something goes wrong there and the settings are missing, it's good that ruby-saml will point them to the right direction.