### PR TITLE
Added Response available options list

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -30,6 +30,15 @@ module OneLogin
 
       attr_accessor :soft
 
+      # Response available options
+      # This is not a whitelist to allow people extending OneLogin::RubySaml:Response
+      # and pass custom options
+      AVAILABLE_OPTIONS = [
+        :allowed_clock_drift, :check_duplicated_attributes, :matches_request_id, :settings, :skip_authnstatement, :skip_conditions,
+        :skip_destination, :skip_recipient_check, :skip_subject_confirmation
+      ]
+      # TODO: Update the comment on initialize to describe every option
+
       # Constructs the SAML Response. A Response Object that is an extension of the SamlMessage class.
       # @param response [String] A UUEncoded SAML response from the IdP.
       # @param options  [Hash]   :settings to provide the OneLogin::RubySaml::Settings object

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -60,6 +60,13 @@ class RubySamlTest < Minitest::Test
       assert_raises(ArgumentError) { OneLogin::RubySaml::Response.new(nil) }
     end
 
+    it "not filter available options only" do
+      options = { :skip_destination => true, :foo => :bar }
+      response = OneLogin::RubySaml::Response.new(response_document_valid_signed, options)
+      assert_includes response.options.keys, :skip_destination
+      assert_includes response.options.keys, :foo
+    end
+
     it "be able to parse a document which contains ampersands" do
       XMLSecurity::SignedDocument.any_instance.stubs(:digests_match?).returns(true)
       OneLogin::RubySaml::Response.any_instance.stubs(:validate_conditions).returns(true)


### PR DESCRIPTION
I recently did a PR in `omniauth-saml` gem to allow more options for a `OneLogin::RubySaml::Response` object (https://github.com/omniauth/omniauth-saml/pull/159).

After merging it, I was discussing with @md5 about the possibility to source the allowed options from `ruby-saml` gem instead of hardcode them in this gem. 

As of today, [`omniauth-saml`](https://rubygems.org/gems/omniauth-saml/) had ~2.3 million downloads and I believe that introducing a whitelist of response options will make the dependency on `ruby-saml` stronger and even more reliable.

Moreover, it will allow to developers who are using `ruby-saml` standalone to have a better overview on the options they can use. 
