### PR TITLE
Support parsing metadata of multiple IdPs at once

### DIFF
--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -145,7 +145,7 @@ module OneLogin
         end
 
         get = Net::HTTP::Get.new(uri.request_uri)
-        response = http.request(get)
+        @response = http.request(get)
         return response.body if response.is_a? Net::HTTPSuccess
 
         raise OneLogin::RubySaml::HttpError.new(

--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -1,6 +1,4 @@
 require "base64"
-require "zlib"
-require "cgi"
 require "net/http"
 require "net/https"
 require "rexml/document"

--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -12,12 +12,23 @@ module OneLogin
     # Auxiliary class to retrieve and parse the Identity Provider Metadata
     #
     class IdpMetadataParser
+      module SamlMetadata
+        module Vocabulary
+          METADATA       = "urn:oasis:names:tc:SAML:2.0:metadata"
+          DSIG           = "http://www.w3.org/2000/09/xmldsig#"
+          NAME_FORMAT    = "urn:oasis:names:tc:SAML:2.0:attrname-format:*"
+          SAML_ASSERTION = "urn:oasis:names:tc:SAML:2.0:assertion"
+        end
 
-      METADATA       = "urn:oasis:names:tc:SAML:2.0:metadata"
-      DSIG           = "http://www.w3.org/2000/09/xmldsig#"
-      NAME_FORMAT    = "urn:oasis:names:tc:SAML:2.0:attrname-format:*"
-      SAML_ASSERTION = "urn:oasis:names:tc:SAML:2.0:assertion"
+        NAMESPACE = {
+          "md" => Vocabulary::METADATA,
+          "NameFormat" => Vocabulary::NAME_FORMAT,
+          "saml" => Vocabulary::SAML_ASSERTION,
+          "ds" => Vocabulary::DSIG
+        }
+      end
 
+      include SamlMetadata::Vocabulary
       attr_reader :document
       attr_reader :response
       attr_reader :options
@@ -98,26 +109,13 @@ module OneLogin
       def parse_to_hash(idp_metadata, options = {})
         @document = REXML::Document.new(idp_metadata)
         @options = options
-        @entity_descriptor = nil
-        @certificates = nil
-        @fingerprint = nil
 
+        idpsso_descriptor = IdpMetadata::get_idps(@document, options[:entity_id])[0]
         if idpsso_descriptor.nil?
           raise ArgumentError.new("idp_metadata must contain an IDPSSODescriptor element")
         end
 
-        {
-          :idp_entity_id => idp_entity_id,
-          :name_identifier_format => idp_name_id_format,
-          :idp_sso_target_url => single_signon_service_url(options),
-          :idp_slo_target_url => single_logout_service_url(options),
-          :idp_attribute_names => attribute_names,
-          :idp_cert => nil,
-          :idp_cert_fingerprint => nil,
-          :idp_cert_multi => nil
-        }.tap do |response_hash|
-          merge_certificates_into(response_hash) unless certificates.nil?
-        end
+        return IdpMetadata.new(idpsso_descriptor, idpsso_descriptor.parent.attributes["entityID"]).to_hash(options)
       end
 
       private
@@ -153,128 +151,129 @@ module OneLogin
         )
       end
 
-      def entity_descriptor
-        @entity_descriptor ||= REXML::XPath.first(
-          document,
-          entity_descriptor_path,
-          namespace
-        )
-      end
-
-      def entity_descriptor_path
-        path = "//md:EntityDescriptor"  
-        entity_id = options[:entity_id] 
-        return path unless entity_id    
-        path << "[@entityID=\"#{entity_id}\"]"
-      end
-
-      def idpsso_descriptor
-        REXML::XPath.first(
-          document,
-          entity_descriptor_path << "/md:IDPSSODescriptor",
-          namespace
-        )
-      end 
-
-      # @return [String|nil] IdP Entity ID value if exists
-      #
-      def idp_entity_id
-        idpsso_descriptor.parent.attributes["entityID"]
-      end
-
-      # @return [String|nil] IdP Name ID Format value if exists
-      #
-      def idp_name_id_format
-        node = REXML::XPath.first(
-          idpsso_descriptor,
-          "md:NameIDFormat",
-          namespace
-        )
-        Utils.element_text(node)
-      end
-
-      # @param binding_priority [Array]
-      # @return [String|nil] SingleSignOnService binding if exists
-      #
-      def single_signon_service_binding(binding_priority = nil)
-        nodes = REXML::XPath.match(
-          idpsso_descriptor,
-          "md:SingleSignOnService/@Binding",
-          namespace
-        )
-        if binding_priority
-          values = nodes.map(&:value)
-          binding_priority.detect{ |binding| values.include? binding }
-        else
-          nodes.first.value if nodes.any?
+      class IdpMetadata
+        def self.get_idps(metadata_document, only_entity_id=nil)
+          path = "//md:EntityDescriptor#{only_entity_id && '[@entityID="' + only_entity_id + '"]'}/md:IDPSSODescriptor"
+          REXML::XPath.match(
+            metadata_document,
+            path,
+            SamlMetadata::NAMESPACE
+          )
         end
-      end
 
-      # @param options [Hash]
-      # @return [String|nil] SingleSignOnService endpoint if exists
-      #
-      def single_signon_service_url(options = {})
-        binding = single_signon_service_binding(options[:sso_binding])
-        unless binding.nil?
+        def initialize(idpsso_descriptor, entity_id)
+          @idpsso_descriptor = idpsso_descriptor
+          @entity_id = entity_id
+        end
+
+        def to_hash(options = {})
+          {
+            :idp_entity_id => @entity_id,
+            :name_identifier_format => idp_name_id_format,
+            :idp_sso_target_url => single_signon_service_url(options),
+            :idp_slo_target_url => single_logout_service_url(options),
+            :idp_attribute_names => attribute_names,
+            :idp_cert => nil,
+            :idp_cert_fingerprint => nil,
+            :idp_cert_multi => nil
+          }.tap do |response_hash|
+            merge_certificates_into(response_hash) unless certificates.nil?
+          end
+        end
+
+        # @return [String|nil] IdP Name ID Format value if exists
+        #
+        def idp_name_id_format
           node = REXML::XPath.first(
-            idpsso_descriptor,
+            @idpsso_descriptor,
+            "md:NameIDFormat",
+            SamlMetadata::NAMESPACE
+          )
+          Utils.element_text(node)
+        end
+
+        # @param binding_priority [Array]
+        # @return [String|nil] SingleSignOnService binding if exists
+        #
+        def single_signon_service_binding(binding_priority = nil)
+          nodes = REXML::XPath.match(
+            @idpsso_descriptor,
+            "md:SingleSignOnService/@Binding",
+            SamlMetadata::NAMESPACE
+          )
+          if binding_priority
+            values = nodes.map(&:value)
+            binding_priority.detect{ |binding| values.include? binding }
+          else
+            nodes.first.value if nodes.any?
+          end
+        end
+
+        # @param options [Hash]
+        # @return [String|nil] SingleSignOnService endpoint if exists
+        #
+        def single_signon_service_url(options = {})
+          binding = single_signon_service_binding(options[:sso_binding])
+          return if binding.nil?
+
+          node = REXML::XPath.first(
+            @idpsso_descriptor,
             "md:SingleSignOnService[@Binding=\"#{binding}\"]/@Location",
-            namespace
+            SamlMetadata::NAMESPACE
           )
           return node.value if node
         end
-      end
 
-      # @param binding_priority [Array]
-      # @return [String|nil] SingleLogoutService binding if exists
-      #
-      def single_logout_service_binding(binding_priority = nil)
-        nodes = REXML::XPath.match(
-          idpsso_descriptor,
-          "md:SingleLogoutService/@Binding",
-          namespace
-        )
-        if binding_priority
-          values = nodes.map(&:value)
-          binding_priority.detect{ |binding| values.include? binding }
-        else
-          nodes.first.value if nodes.any?
+        # @param binding_priority [Array]
+        # @return [String|nil] SingleLogoutService binding if exists
+        #
+        def single_logout_service_binding(binding_priority = nil)
+          nodes = REXML::XPath.match(
+            @idpsso_descriptor,
+            "md:SingleLogoutService/@Binding",
+            SamlMetadata::NAMESPACE
+          )
+          if binding_priority
+            values = nodes.map(&:value)
+            binding_priority.detect{ |binding| values.include? binding }
+          else
+            nodes.first.value if nodes.any?
+          end
         end
-      end
 
-      # @param options [Hash]
-      # @return [String|nil] SingleLogoutService endpoint if exists
-      #
-      def single_logout_service_url(options = {})
-        binding = single_logout_service_binding(options[:slo_binding])
-        unless binding.nil?
+        # @param options [Hash]
+        # @return [String|nil] SingleLogoutService endpoint if exists
+        #
+        def single_logout_service_url(options = {})
+          binding = single_logout_service_binding(options[:slo_binding])
+          return if binding.nil?
+
           node = REXML::XPath.first(
-            idpsso_descriptor,
+            @idpsso_descriptor,
             "md:SingleLogoutService[@Binding=\"#{binding}\"]/@Location",
-            namespace
+            SamlMetadata::NAMESPACE
           )
           return node.value if node
         end
-      end
 
-      # @return [String|nil] Unformatted Certificate if exists
-      #
-      def certificates
-        @certificates ||= begin
-          signing_nodes = REXML::XPath.match(
-            idpsso_descriptor,
-            "md:KeyDescriptor[not(contains(@use, 'encryption'))]/ds:KeyInfo/ds:X509Data/ds:X509Certificate",
-            namespace
-          )
+        # @return [String|nil] Unformatted Certificate if exists
+        #
+        def certificates
+          @certificates ||= begin
+            signing_nodes = REXML::XPath.match(
+              @idpsso_descriptor,
+              "md:KeyDescriptor[not(contains(@use, 'encryption'))]/ds:KeyInfo/ds:X509Data/ds:X509Certificate",
+              SamlMetadata::NAMESPACE
+            )
 
-          encryption_nodes = REXML::XPath.match(
-            idpsso_descriptor,
-            "md:KeyDescriptor[not(contains(@use, 'signing'))]/ds:KeyInfo/ds:X509Data/ds:X509Certificate",
-            namespace
-          )
+            encryption_nodes = REXML::XPath.match(
+              @idpsso_descriptor,
+              "md:KeyDescriptor[not(contains(@use, 'signing'))]/ds:KeyInfo/ds:X509Data/ds:X509Certificate",
+              SamlMetadata::NAMESPACE
+            )
 
-          certs = nil
-          unless signing_nodes.empty? && encryption_nodes.empty?
+            return nil if signing_nodes.empty? && encryption_nodes.empty?
+
             certs = {}
             unless signing_nodes.empty?
               certs['signing'] = []
@@ -289,71 +288,62 @@ module OneLogin
                 certs['encryption'] << Utils.element_text(cert_node)
               end
             end
+            certs
           end
-          certs
         end
-      end
 
-      # @return [String|nil] the fingerpint of the X509Certificate if it exists
-      #
-      def fingerprint(certificate, fingerprint_algorithm = XMLSecurity::Document::SHA1)
-        @fingerprint ||= begin
-          if certificate
+        # @return [String|nil] the fingerpint of the X509Certificate if it exists
+        #
+        def fingerprint(certificate, fingerprint_algorithm = XMLSecurity::Document::SHA1)
+          @fingerprint ||= begin
+            return unless certificate
+
             cert = OpenSSL::X509::Certificate.new(Base64.decode64(certificate))
 
             fingerprint_alg = XMLSecurity::BaseDocument.new.algorithm(fingerprint_algorithm).new
             fingerprint_alg.hexdigest(cert.to_der).upcase.scan(/../).join(":")
           end
         end
-      end
 
-      # @return [Array] the names of all SAML attributes if any exist
-      #
-      def attribute_names
-        nodes = REXML::XPath.match(
-          idpsso_descriptor,
-          "saml:Attribute/@Name",
-          namespace
-        )
-        nodes.map(&:value)
-      end
+        # @return [Array] the names of all SAML attributes if any exist
+        #
+        def attribute_names
+          nodes = REXML::XPath.match(
+            @idpsso_descriptor  ,
+            "saml:Attribute/@Name",
+            SamlMetadata::NAMESPACE
+          )
+          nodes.map(&:value)
+        end
 
-      def namespace
-        {
-          "md" => METADATA,
-          "NameFormat" => NAME_FORMAT,
-          "saml" => SAML_ASSERTION,
-          "ds" => DSIG
-        }
-      end
-
-      def merge_certificates_into(parsed_metadata)
-        if (certificates.size == 1 &&
+        def merge_certificates_into(parsed_metadata)
+          if (certificates.size == 1 &&
               (certificates_has_one('signing') || certificates_has_one('encryption'))) ||
               (certificates_has_one('signing') && certificates_has_one('encryption') &&
               certificates["signing"][0] == certificates["encryption"][0])
 
-          if certificates.key?("signing")
-            parsed_metadata[:idp_cert] = certificates["signing"][0]
-            parsed_metadata[:idp_cert_fingerprint] = fingerprint(
-              parsed_metadata[:idp_cert],
-              parsed_metadata[:idp_cert_fingerprint_algorithm]
-            )
+            if certificates.key?("signing")
+              parsed_metadata[:idp_cert] = certificates["signing"][0]
+              parsed_metadata[:idp_cert_fingerprint] = fingerprint(
+                parsed_metadata[:idp_cert],
+                parsed_metadata[:idp_cert_fingerprint_algorithm]
+              )
+            else
+              parsed_metadata[:idp_cert] = certificates["encryption"][0]
+              parsed_metadata[:idp_cert_fingerprint] = fingerprint(
+                parsed_metadata[:idp_cert],
+                parsed_metadata[:idp_cert_fingerprint_algorithm]
+              )
+            end
           else
-            parsed_metadata[:idp_cert] = certificates["encryption"][0]
-            parsed_metadata[:idp_cert_fingerprint] = fingerprint(
-              parsed_metadata[:idp_cert],
-              parsed_metadata[:idp_cert_fingerprint_algorithm]
-            )
+            # symbolize keys of certificates and pass it on
+            parsed_metadata[:idp_cert_multi] = Hash[certificates.map { |k, v| [k.to_sym, v] }]
           end
-        else
-          # symbolize keys of certificates and pass it on
-          parsed_metadata[:idp_cert_multi] = Hash[certificates.map { |k, v| [k.to_sym, v] }]
         end
-      end
 
-      def certificates_has_one(key)
-        certificates.key?(key) && certificates[key].size == 1
+        def certificates_has_one(key)
+          certificates.key?(key) && certificates[key].size == 1
+        end
       end
 
       def merge_parsed_metadata_into(settings, parsed_metadata)
@@ -363,6 +353,8 @@ module OneLogin
 
         settings
       end
+
+      private_constant :SamlMetadata, :IdpMetadata
     end
   end
 end

--- a/test/idp_metadata_parser_test.rb
+++ b/test/idp_metadata_parser_test.rb
@@ -342,6 +342,14 @@ class IdpMetadataParserTest < Minitest::Test
       assert_equal "https://hello.example.com/access/saml/logout", @settings.idp_slo_target_url
       assert_equal ["AuthToken", "SSOStartPage"], @settings.idp_attribute_names
     end
+
+    it "should handle multiple descriptors at once" do
+      settings = @idp_metadata_parser.parse_to_array(@idp_metadata)
+      assert_equal "https://foo.example.com/access/saml/idp.xml", settings.first[:idp_entity_id]
+      assert_equal "F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72", settings.first[:idp_cert_fingerprint]
+      assert_equal "https://bar.example.com/access/saml/idp.xml", settings.last[:idp_entity_id]
+      assert_equal "F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72", settings.last[:idp_cert_fingerprint]
+    end
   end
 
   describe "parsing metadata with no IDPSSODescriptor element" do


### PR DESCRIPTION
I wanted to discover all IdPs involved in a federation, but `IdpMetadataParser` only supported getting one at a time. This introduces new methods which return all found IdPs as an array, not changing established interface.

Working on this I also stumbled on the bug that ”implicitly choose first found IdP” failed if there were SP `EntityDescriptor`s before IdP ones. The refactoring commit below the new functionality fixes this and adds a corresponding test case.