### PR TITLE
Partial attributes to security settings doesn't nullify missing ones

### DIFF
--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -10,7 +10,9 @@ module OneLogin
     #
     class Settings
       def initialize(overrides = {})
+        security_attributes = overrides.delete(:security) || {}
         config = DEFAULTS.merge(overrides)
+        config[:security] = DEFAULTS[:security].merge(security_attributes)
         config.each do |k,v|
           acc = "#{k.to_s}=".to_sym
           if respond_to? acc

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -9,10 +9,15 @@ module OneLogin
     # SAML2 Toolkit Settings
     #
     class Settings
-      def initialize(overrides = {})
-        security_attributes = overrides.delete(:security) || {}
-        config = DEFAULTS.merge(overrides)
-        config[:security] = DEFAULTS[:security].merge(security_attributes)
+      def initialize(overrides = {}, keep_security_attributes = false)
+        if keep_security_attributes
+          security_attributes = overrides.delete(:security) || {}
+          config = DEFAULTS.merge(overrides)
+          config[:security] = DEFAULTS[:security].merge(security_attributes)
+        else
+          config = DEFAULTS.merge(overrides)
+        end
+
         config.each do |k,v|
           acc = "#{k.to_s}=".to_sym
           if respond_to? acc

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -77,6 +77,20 @@ class SettingsTest < Minitest::Test
       assert_equal new_settings.security[:signature_method], XMLSecurity::Document::RSA_SHA1
     end
 
+    it "overrides only provided security attributes" do
+      config = {
+        security: {
+          metadata_signed: true
+        }
+      }
+
+      @default_attributes = OneLogin::RubySaml::Settings::DEFAULTS
+
+      @settings = OneLogin::RubySaml::Settings.new(config)
+      assert_equal @settings.security[:metadata_signed], true
+      assert_equal @settings.security[:digest_method], @default_attributes[:security][:digest_method]
+    end
+
     describe "#single_logout_service_url" do
       it "when single_logout_service_url is nil but assertion_consumer_logout_service_url returns its value" do
         @settings.single_logout_service_url = nil

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -79,8 +79,8 @@ class SettingsTest < Minitest::Test
 
     it "overrides only provided security attributes" do
       config = {
-        security: {
-          metadata_signed: true
+        :security => {
+          :metadata_signed => true
         }
       }
 
@@ -107,7 +107,7 @@ class SettingsTest < Minitest::Test
 
         assert_equal "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect", @settings.single_logout_service_binding
       end
-    end    
+    end
 
     describe "#get_idp_cert" do
       it "returns nil when the cert is an empty string" do
@@ -183,7 +183,7 @@ class SettingsTest < Minitest::Test
 
         assert @settings.get_idp_cert_multi.kind_of? Hash
         assert @settings.get_idp_cert_multi[:signing].kind_of? Array
-        assert @settings.get_idp_cert_multi[:encryption].kind_of? Array        
+        assert @settings.get_idp_cert_multi[:encryption].kind_of? Array
         assert @settings.get_idp_cert_multi[:signing][0].kind_of? OpenSSL::X509::Certificate
         assert @settings.get_idp_cert_multi[:encryption][0].kind_of? OpenSSL::X509::Certificate
       end

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -77,7 +77,21 @@ class SettingsTest < Minitest::Test
       assert_equal new_settings.security[:signature_method], XMLSecurity::Document::RSA_SHA1
     end
 
-    it "overrides only provided security attributes" do
+    it "overrides only provided security attributes passing a second parameter" do
+      config = {
+        :security => {
+          :metadata_signed => true
+        }
+      }
+
+      @default_attributes = OneLogin::RubySaml::Settings::DEFAULTS
+
+      @settings = OneLogin::RubySaml::Settings.new(config, true)
+      assert_equal @settings.security[:metadata_signed], true
+      assert_equal @settings.security[:digest_method], @default_attributes[:security][:digest_method]
+    end
+
+    it "doesn't override only provided security attributes without passing a second parameter" do
       config = {
         :security => {
           :metadata_signed => true
@@ -88,7 +102,7 @@ class SettingsTest < Minitest::Test
 
       @settings = OneLogin::RubySaml::Settings.new(config)
       assert_equal @settings.security[:metadata_signed], true
-      assert_equal @settings.security[:digest_method], @default_attributes[:security][:digest_method]
+      assert_equal @settings.security[:digest_method], nil
     end
 
     describe "#single_logout_service_url" do


### PR DESCRIPTION
I supposed this was a bug, because if I want to enable metadata signing I need to provide all attributes, while I just want to enable it without change other attributes.

