### PR TITLE
Update README to fix Logger usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ To override the default behavior and control the destination of log messages, pr
 a ruby Logger object to the gem's logging singleton:
 
 ```ruby
-OneLogin::RubySaml::Logging.logger = Logger.new(File.open('/var/log/ruby-saml.log', 'w'))
+OneLogin::RubySaml::Logging.logger = Logger.new('/var/log/ruby-saml.log')
 ```
 
 ## The Initialization Phase


### PR DESCRIPTION
I got the same issue as following.
https://github.com/onelogin/ruby-saml/issues/436

As I commented in it, I think the usage of Ruby standard Logger class is wrong in README text.