### PR TITLE
Update supported ruby versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ We created a demo project for Rails4 that uses the latest version of this librar
 * 2.2.x
 * 2.3.x
 * 2.4.x
+* 2.5.x
 * JRuby 1.7.19
 * JRuby 9.0.0.0
 * JRuby 9.2.0.0


### PR DESCRIPTION
In travis ci, the tests seem to run also on ruby 2.5 version environment.
https://github.com/onelogin/ruby-saml/blob/master/.travis.yml#L11