### PR TITLE
Override 'method_missing' in Attributes class to treat is a Hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Ruby SAML [![Build Status](https://secure.travis-ci.org/onelogin/ruby-saml.png)](http://travis-ci.org/onelogin/ruby-saml)
 
+## Note on versions 0.8.6 and 0.8.7
+Version `0.8.6` introduced an incompatibility with regards to manipulating the `OneLogin::RubySaml::Response#attributes` property; in this version 
+the `#attributes` property is a class (`OneLogin::RubySaml::Attributes`) which implements the `Enumerator` module, thus any non-overriden Hash method
+will throw a NoMethodError.
+Version `0.8.7` overrides the behavior of class `OneLogin::RubySaml::Attributes` by making any method not found on the class be tested on the 
+internal hash structure, thus all methods available in the `Hash` class are now available in `OneLogin::RubySaml::Response#attributes`.
+
 ## Updating from 0.7.x to 0.8.x
 Version `0.8.x` changes the namespace of the gem from `OneLogin::Saml` to `OneLogin::RubySaml`.  Please update your implementations of the gem accordingly.
 

--- a/lib/onelogin/ruby-saml/attributes.rb
+++ b/lib/onelogin/ruby-saml/attributes.rb
@@ -65,7 +65,14 @@ module OneLogin
       #
       def multi(name)
         values = attributes[canonize_name(name)] || attributes[name]
-        values.is_a?(Array) ? values : Array(values)
+        
+        if values.is_a?(Array)
+          values
+        elsif !values.nil?
+          Array(values)
+        else
+          nil
+        end
       end
 
       # Retrieve attribute value(s)

--- a/lib/onelogin/ruby-saml/attributes.rb
+++ b/lib/onelogin/ruby-saml/attributes.rb
@@ -56,8 +56,7 @@ module OneLogin
       # @return [String] The value (First occurrence)
       #
       def single(name)
-        values = multi(name)
-        values.first if include?(name)
+        multi(name).first if include?(name)
       end
 
       # Return all values for an attribute
@@ -65,7 +64,8 @@ module OneLogin
       # @return [Array] Values of the attribute
       #
       def multi(name)
-        attributes[canonize_name(name)] || attributes[name]
+        values = attributes[canonize_name(name)] || attributes[name]
+        values.is_a?(Array) ? values : Array(values)
       end
 
       # Retrieve attribute value(s)

--- a/lib/onelogin/ruby-saml/attributes.rb
+++ b/lib/onelogin/ruby-saml/attributes.rb
@@ -113,6 +113,10 @@ module OneLogin
         end
       end
 
+      def respond_to?(name)
+        attributes.respond_to?(name) || super
+      end
+
       protected
 
       # stringifies all names so both 'email' and :email return the same result
@@ -123,6 +127,13 @@ module OneLogin
         name.to_s
       end
 
+      def method_missing(name, *args, &block)
+        if attributes.respond_to?(name)
+          attributes.send(name, *args, &block)
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/lib/onelogin/ruby-saml/attributes.rb
+++ b/lib/onelogin/ruby-saml/attributes.rb
@@ -56,7 +56,8 @@ module OneLogin
       # @return [String] The value (First occurrence)
       #
       def single(name)
-        (attributes[canonize_name(name)] || attributes[name]).first if include?(name)
+        values = multi(name)
+        values.first if include?(name)
       end
 
       # Return all values for an attribute

--- a/lib/onelogin/ruby-saml/attributes.rb
+++ b/lib/onelogin/ruby-saml/attributes.rb
@@ -48,7 +48,7 @@ module OneLogin
       # @param name [String] The attribute name to be checked
       #
       def include?(name)
-        attributes.has_key?(canonize_name(name))
+        attributes.has_key?(canonize_name(name)) || attributes.has_key?(name)
       end
       
       # Return first value for an attribute
@@ -56,7 +56,7 @@ module OneLogin
       # @return [String] The value (First occurrence)
       #
       def single(name)
-        attributes[canonize_name(name)].first if include?(name)
+        (attributes[canonize_name(name)] || attributes[name]).first if include?(name)
       end
 
       # Return all values for an attribute
@@ -64,7 +64,7 @@ module OneLogin
       # @return [Array] Values of the attribute
       #
       def multi(name)
-        attributes[canonize_name(name)]
+        attributes[canonize_name(name)] || attributes[name]
       end
 
       # Retrieve attribute value(s)
@@ -76,7 +76,7 @@ module OneLogin
       #                          response.attributes['mail']  # => ['user@example.com','user@example.net']
       #
       def [](name)
-        self.class.single_value_compatibility ? single(canonize_name(name)) : multi(canonize_name(name))
+        self.class.single_value_compatibility ? single(name) : multi(name)
       end
 
       # @return [Array] Return all attributes as an array

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -239,14 +239,24 @@ class RubySamlTest < Test::Unit::TestCase
 
       should "be manipulable by hash methods such as #merge and not raise an exception" do
         response = OneLogin::RubySaml::Response.new(response_document)
-        test_hash = { :testing_attribute => "test" }
         response.attributes.merge({ :testing_attribute => "test" })
       end
 
       should "be manipulable by hash methods such as #shift and not raise an exception" do
         response = OneLogin::RubySaml::Response.new(response_document)
-        test_hash = { :testing_attribute => "test" }
         response.attributes.shift
+      end
+
+      should "be manipulable by hash methods such as #merge! and actually contain the value" do
+        response = OneLogin::RubySaml::Response.new(response_document)
+        response.attributes.merge!({ :testing_attribute => "test" })
+        assert response.attributes[:testing_attribute]
+      end
+
+      should "be manipulable by hash methods such as #shift and actually remove the value" do
+        response = OneLogin::RubySaml::Response.new(response_document)
+        removed_value = response.attributes.shift
+        assert_nil response.attributes[removed_value[0]]
       end
     end
 

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -236,6 +236,18 @@ class RubySamlTest < Test::Unit::TestCase
         assert_equal "smith", response_with_multiple_attribute_statements.attributes[:surname]
         assert_equal "bob", response_with_multiple_attribute_statements.attributes[:firstname]
       end
+
+      should "be manipulable by hash methods such as #merge and not raise an exception" do
+        response = OneLogin::RubySaml::Response.new(response_document)
+        test_hash = { :testing_attribute => "test" }
+        response.attributes.merge({ :testing_attribute => "test" })
+      end
+
+      should "be manipulable by hash methods such as #shift and not raise an exception" do
+        response = OneLogin::RubySaml::Response.new(response_document)
+        test_hash = { :testing_attribute => "test" }
+        response.attributes.shift
+      end
     end
 
     context "#session_expires_at" do


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
This PR allows the Attributes class to behave as a simple hash when operating over it.

## Steps to Test or Reproduce
1. Obtain a SAML Response with an `AttributeStatement` node containing attributes with multiple values, such as [this one](https://github.com/onelogin/ruby-saml/blob/010281f5fa4ffa2a718b45907d1c005a6f088564/test/responses/response_with_multiple_attribute_values.xml) and store it in a variable (Let's say `saml_response_doc`).
2. Instantiate a Response object.
```ruby 
response = OneLogin::RubySaml::Response.new(saml_response_doc)
```
3. Call `#shift` on `response.attributes`
```ruby
removed_attributes = response.attributes.shift
```
4. Verify that your removed value is correct.

## Impacted Areas in Application
* SAML Response attributes parsing