### PR TITLE
Explicit about the error when signed element is not found and found m…

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -821,6 +821,11 @@ module OneLogin
         end
 
         if sig_elements.size != 1
+          if  sig_elements.size == 0
+             append_error("Signed element id ##{doc.signed_element_id} is not found")
+          else
+             append_error("Signed element id ##{doc.signed_element_id} is found more than once")
+          end
           return append_error(error_msg)
         end
 

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -905,6 +905,7 @@ class RubySamlTest < Minitest::Test
         response_wrapped.settings = settings
         assert !response_wrapped.send(:validate_signature)
         assert_includes response_wrapped.errors, "Invalid Signature on SAML Response"
+        assert_includes response_wrapped.errors, "Signed element id #pfxc3d2b542-0f7e-8767-8e87-5b0dc6913375 is not found"
       end
     end
 


### PR DESCRIPTION
# Purpose
It is unclear what goes wrong from a caller's stand point when it only gets the generic message "Invalid Signature on SAML Response".   

This PR is to set the error message about what goes wrong when the signed element id is found more than once or not found. 
