### PR TITLE
Make CI 💚

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.5
@@ -9,7 +8,6 @@ rvm:
   - 2.3.0
   - 2.4.0
   - 2.5.0
-  - ree
   - jruby-1.7.27
   - jruby-9.1.17.0
   - jruby-9.2.0.0
@@ -20,8 +18,6 @@ before_install:
   - gem update bundler
 matrix:
   exclude:
-    - rvm: 1.8.7
-      gemfile: Gemfile
     - rvm: ree
       gemfile: Gemfile
     - rvm: jruby-1.7.27

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,17 @@ matrix:
       gemfile: gemfiles/nokogiri-1.5.gemfile
     - rvm: jruby-9.2.0.0
       gemfile: gemfiles/nokogiri-1.5.gemfile
+    - rvm: 2.1.5
+      gemfile: gemfiles/nokogiri-1.5.gemfile
+    - rvm: 2.2.0
+      gemfile: gemfiles/nokogiri-1.5.gemfile
+    - rvm: 2.3.0
+      gemfile: gemfiles/nokogiri-1.5.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/nokogiri-1.5.gemfile
+    - rvm: 2.5.0
+      gemfile: gemfiles/nokogiri-1.5.gemfile
+    - rvm: 2.6.2
+      gemfile: gemfiles/nokogiri-1.5.gemfile
 env:
   - JRUBY_OPTS="--debug"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ SAML authorization is a two step process and you are expected to implement suppo
 We created a demo project for Rails4 that uses the latest version of this library: [ruby-saml-example](https://github.com/onelogin/ruby-saml-example)
 
 ### Supported versions of Ruby
-* 1.8.7
 * 1.9.x
 * 2.0.x
 * 2.1.x
@@ -151,22 +150,6 @@ or just the required components individually:
 ```ruby
 require 'onelogin/ruby-saml/authrequest'
 ```
-
-### Installation on Ruby 1.8.7
-
-This gem uses Nokogiri as a dependency, which dropped support for Ruby 1.8.x in Nokogiri 1.6. When installing this gem on Ruby 1.8.7, you will need to make sure a version of Nokogiri prior to 1.6 is installed or specified if it hasn't been already.
-
-Using `Gemfile`
-
-```ruby
-gem 'nokogiri', '~> 1.5.10'
-```
-
-Using RubyGems
-
-```sh
-gem install nokogiri --version '~> 1.5.10'
-````
 
 ### Configuring Logging
 

--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -165,12 +165,6 @@ module OneLogin
           http.use_ssl = true
           # Most IdPs will probably use self signed certs
           http.verify_mode = validate_cert ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
-
-          # Net::HTTP in Ruby 1.8 did not set the default certificate store
-          # automatically when VERIFY_PEER was specified.
-          if RUBY_VERSION < '1.9' && !http.ca_file && !http.ca_path && !http.cert_store
-            http.cert_store = OpenSSL::SSL::SSLContext::DEFAULT_CERT_STORE
-          end
         end
 
         get = Net::HTTP::Get.new(uri.request_uri)

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -918,12 +918,7 @@ module OneLogin
           raise ValidationError.new('An EncryptedAssertion found and no SP private key found on the settings to decrypt it. Be sure you provided the :settings parameter at the initialize method')
         end
 
-        # Marshal at Ruby 1.8.7 throw an Exception
-        if RUBY_VERSION < "1.9"
-          document_copy = XMLSecurity::SignedDocument.new(response, errors)
-        else
-          document_copy = Marshal.load(Marshal.dump(document))
-        end
+        document_copy = Marshal.load(Marshal.dump(document))
 
         decrypt_assertion_from_document(document_copy)
       end

--- a/lib/onelogin/ruby-saml/utils.rb
+++ b/lib/onelogin/ruby-saml/utils.rb
@@ -1,8 +1,4 @@
-if RUBY_VERSION < '1.9'
-  require 'uuid'
-else
-  require 'securerandom'
-end
+require 'securerandom'
 
 module OneLogin
   module RubySaml
@@ -10,7 +6,6 @@ module OneLogin
     # SAML2 Auxiliary class
     #
     class Utils
-      @@uuid_generator = UUID.new if RUBY_VERSION < '1.9'
 
       DSIG      = "http://www.w3.org/2000/09/xmldsig#"
       XENC      = "http://www.w3.org/2001/04/xmlenc#"
@@ -256,7 +251,7 @@ module OneLogin
       end
 
       def self.uuid
-        RUBY_VERSION < '1.9' ? "_#{@@uuid_generator.generate}" : "_#{SecureRandom.uuid}"
+        "_#{SecureRandom.uuid}"
       end
 
       # Given two strings, attempt to match them as URIs using Rails' parse method.  If they can be parsed,

--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -21,13 +21,10 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.7}
-  s.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = '>= 1.9.3'
   s.summary = %q{SAML Ruby Tookit}
   s.test_files = `git ls-files test/*`.split("\n")
 
-  # Because runtime dependencies are determined at build time, we cannot make
-  # Nokogiri's version dependent on the Ruby version, even though we would
-  # have liked to constrain Ruby 1.8.7 to install only the 1.5.x versions.
   if defined?(JRUBY_VERSION)
     if JRUBY_VERSION < '9.2.0.0'
       s.add_runtime_dependency('nokogiri', '>= 1.8.2', '<= 1.8.5')
@@ -35,9 +32,6 @@ Gem::Specification.new do |s|
     else
       s.add_runtime_dependency('nokogiri', '>= 1.8.2')
     end
-  elsif RUBY_VERSION < '1.9'
-    s.add_runtime_dependency('uuid')
-    s.add_runtime_dependency('nokogiri', '<= 1.5.11')
   elsif RUBY_VERSION < '2.1'
     s.add_runtime_dependency('nokogiri', '>= 1.5.10', '<= 1.6.8.1')
   else
@@ -55,9 +49,6 @@ Gem::Specification.new do |s|
   if defined?(JRUBY_VERSION)
     # All recent versions of JRuby play well with pry
     s.add_development_dependency('pry')
-  elsif RUBY_VERSION < '1.9'
-    # 1.8.7
-    s.add_development_dependency('ruby-debug', '~> 0.10.4')
   elsif RUBY_VERSION < '2.0'
     # 1.9.x
     s.add_development_dependency('debugger-linecache', '~> 1.2.0')


### PR DESCRIPTION
In creating #495 I noticed there was a lot of repeat failures in the CI pipeline. They seemed to stem from 2 issues:
 - Running Ruby versions against an old unsupported version of Nokogiri
 - Failing specs due to ruby-saml not being compatible with Ruby v1.8.7 anymore

This PR tries to resolve both those issues by excluding incompatible ruby/nokogiri builds and removing support for ruby 1.8.7 in order to make CI 💚