### PR TITLE
Add valid until accessor to parsed metadata

### DIFF
--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -228,7 +228,8 @@ module OneLogin
         # @return [String|nil] 'validUntil' attribute of metadata
         #
         def valid_until
-          @idpsso_descriptor.parent&.attributes&.[]('validUntil')
+          root = @idpsso_descriptor.root
+          root.attributes['validUntil'] if root && root.attributes
         end
 
         # @param binding_priority [Array]

--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -207,7 +207,8 @@ module OneLogin
             :idp_attribute_names => attribute_names,
             :idp_cert => nil,
             :idp_cert_fingerprint => nil,
-            :idp_cert_multi => nil
+            :idp_cert_multi => nil,
+            :valid_until => valid_until
           }.tap do |response_hash|
             merge_certificates_into(response_hash) unless certificates.nil?
           end
@@ -222,6 +223,12 @@ module OneLogin
             SamlMetadata::NAMESPACE
           )
           Utils.element_text(node)
+        end
+
+        # @return [String|nil] 'validUntil' attribute of metadata
+        #
+        def valid_until
+          @idpsso_descriptor.parent&.attributes&.[]('validUntil')
         end
 
         # @param binding_priority [Array]

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -38,6 +38,7 @@ module OneLogin
       attr_accessor :idp_cert_multi
       attr_accessor :idp_attribute_names
       attr_accessor :idp_name_qualifier
+      attr_accessor :valid_until
       # SP Data
       attr_accessor :issuer
       attr_accessor :assertion_consumer_service_url

--- a/test/idp_metadata_parser_test.rb
+++ b/test/idp_metadata_parser_test.rb
@@ -29,6 +29,7 @@ class IdpMetadataParserTest < Minitest::Test
       assert_equal "https://hello.example.com/access/saml/logout", settings.idp_slo_target_url
       assert_equal "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified", settings.name_identifier_format
       assert_equal ["AuthToken", "SSOStartPage"], settings.idp_attribute_names
+      assert_equal '2014-04-17T18:02:33.910Z', settings.valid_until
     end
 
     it "extract certificate from md:KeyDescriptor[@use='signing']" do
@@ -76,7 +77,7 @@ class IdpMetadataParserTest < Minitest::Test
 
       options[:sso_binding] = ['invalid_binding', 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect']
       settings = idp_metadata_parser.parse(idp_metadata, options)
-      assert_equal "https://idp.example.com/idp/profile/SAML2/Redirect/SSO", settings.idp_sso_target_url      
+      assert_equal "https://idp.example.com/idp/profile/SAML2/Redirect/SSO", settings.idp_sso_target_url
     end
 
     it "uses settings options as hash for overrides" do
@@ -121,6 +122,7 @@ class IdpMetadataParserTest < Minitest::Test
       assert_equal "https://hello.example.com/access/saml/logout", metadata[:idp_slo_target_url]
       assert_equal "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified", metadata[:name_identifier_format]
       assert_equal ["AuthToken", "SSOStartPage"], metadata[:idp_attribute_names]
+      assert_equal '2014-04-17T18:02:33.910Z', metadata[:valid_until]
     end
 
     it "extract certificate from md:KeyDescriptor[@use='signing']" do
@@ -242,6 +244,7 @@ class IdpMetadataParserTest < Minitest::Test
       assert_equal "https://hello.example.com/access/saml/logout", settings.idp_slo_target_url
       assert_equal "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified", settings.name_identifier_format
       assert_equal ["AuthToken", "SSOStartPage"], settings.idp_attribute_names
+      assert_equal '2014-04-17T18:02:33.910Z', settings.valid_until
       assert_equal OpenSSL::SSL::VERIFY_PEER, @http.verify_mode
     end
 
@@ -275,6 +278,7 @@ class IdpMetadataParserTest < Minitest::Test
       assert_equal "https://hello.example.com/access/saml/logout", parsed_metadata[:idp_slo_target_url]
       assert_equal "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified", parsed_metadata[:name_identifier_format]
       assert_equal ["AuthToken", "SSOStartPage"], parsed_metadata[:idp_attribute_names]
+      assert_equal '2014-04-17T18:02:33.910Z', settings.valid_until
       assert_equal OpenSSL::SSL::VERIFY_PEER, @http.verify_mode
     end
 
@@ -341,14 +345,17 @@ class IdpMetadataParserTest < Minitest::Test
       assert_equal "F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72", @settings.idp_cert_fingerprint
       assert_equal "https://hello.example.com/access/saml/logout", @settings.idp_slo_target_url
       assert_equal ["AuthToken", "SSOStartPage"], @settings.idp_attribute_names
+      assert_equal '2014-04-17T18:02:33.910Z', @settings.valid_until
     end
 
     it "should handle multiple descriptors at once" do
       settings = @idp_metadata_parser.parse_to_array(@idp_metadata)
       assert_equal "https://foo.example.com/access/saml/idp.xml", settings.first[:idp_entity_id]
       assert_equal "F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72", settings.first[:idp_cert_fingerprint]
+      assert_equal '2014-04-17T18:02:33.910Z', settings.first.valid_until
       assert_equal "https://bar.example.com/access/saml/idp.xml", settings.last[:idp_entity_id]
       assert_equal "08:EB:6E:60:A2:14:4E:89:EC:FA:05:74:9D:72:BF:5D:BE:54:F0:1A", settings.last[:idp_cert_fingerprint]
+      assert_equal '2014-04-17T18:02:33.910Z', settings.last.valid_until
     end
   end
 

--- a/test/idp_metadata_parser_test.rb
+++ b/test/idp_metadata_parser_test.rb
@@ -278,7 +278,7 @@ class IdpMetadataParserTest < Minitest::Test
       assert_equal "https://hello.example.com/access/saml/logout", parsed_metadata[:idp_slo_target_url]
       assert_equal "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified", parsed_metadata[:name_identifier_format]
       assert_equal ["AuthToken", "SSOStartPage"], parsed_metadata[:idp_attribute_names]
-      assert_equal '2014-04-17T18:02:33.910Z', settings.valid_until
+      assert_equal '2014-04-17T18:02:33.910Z', parsed_metadata[:valid_until]
       assert_equal OpenSSL::SSL::VERIFY_PEER, @http.verify_mode
     end
 
@@ -352,10 +352,10 @@ class IdpMetadataParserTest < Minitest::Test
       settings = @idp_metadata_parser.parse_to_array(@idp_metadata)
       assert_equal "https://foo.example.com/access/saml/idp.xml", settings.first[:idp_entity_id]
       assert_equal "F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72", settings.first[:idp_cert_fingerprint]
-      assert_equal '2014-04-17T18:02:33.910Z', settings.first.valid_until
+      assert_equal '2014-04-17T18:02:33.910Z', settings.first[:valid_until]
       assert_equal "https://bar.example.com/access/saml/idp.xml", settings.last[:idp_entity_id]
       assert_equal "08:EB:6E:60:A2:14:4E:89:EC:FA:05:74:9D:72:BF:5D:BE:54:F0:1A", settings.last[:idp_cert_fingerprint]
-      assert_equal '2014-04-17T18:02:33.910Z', settings.last.valid_until
+      assert_equal '2014-04-17T18:02:33.910Z', settings.last[:valid_until]
     end
   end
 

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -11,7 +11,7 @@ class SettingsTest < Minitest::Test
 
     it "should provide getters and settings" do
       accessors = [
-        :idp_entity_id, :idp_sso_target_url, :idp_slo_target_url,
+        :idp_entity_id, :idp_sso_target_url, :idp_slo_target_url, :valid_until,
         :idp_cert, :idp_cert_fingerprint, :idp_cert_fingerprint_algorithm, :idp_cert_multi,
         :idp_attribute_names, :issuer, :assertion_consumer_service_url, :assertion_consumer_service_binding,
         :single_logout_service_url, :single_logout_service_binding,
@@ -40,6 +40,7 @@ class SettingsTest < Minitest::Test
           :idp_sso_target_url => "http://sso.muda.no/sso",
           :idp_slo_target_url => "http://sso.muda.no/slo",
           :idp_cert_fingerprint => "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
+          :valid_until => '2029-04-16T03:35:08.277Z',
           :name_identifier_format => "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
           :attributes_index => 30,
           :passive => true,


### PR DESCRIPTION
## Status
READY

## Issue
Fixes #500 

## Description
Adds `valid_until` attribute to parsed metadata settings. This is useful for cache control purposes.

## Impacted Areas in Application
* `IdpMetadataParser`
* `Settings`