### PR TITLE
Gemspec: drop rubyforge_project metadata

### DIFF
--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   ]
   s.files = `git ls-files`.split("\n")
   s.homepage = %q{http://github.com/onelogin/ruby-saml}
-  s.rubyforge_project = %q{http://www.rubygems.org/gems/ruby-saml}
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.7}


### PR DESCRIPTION
This setting is definitely old, and should be removed.

Future: There's a set of gemspec [metadata](https://guides.rubygems.org/specification-reference/#metadata) to be used with newer RubyGems.

These metadata are then surfaced in the RubyGems.org website interface.

