### PR TITLE
Add coveralls gem and use its formatter

### DIFF
--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency('nokogiri', '>= 1.5.10')
   end
 
+  s.add_development_dependency('coveralls')
   s.add_development_dependency('minitest', '~> 5.5')
   s.add_development_dependency('mocha',    '~> 0.14')
   s.add_development_dependency('rake',     '~> 10')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,7 @@
 require 'simplecov'
+require 'coveralls'
 
+SimpleCov.formatter = Coveralls::SimpleCov::Formatter
 SimpleCov.start do
   add_filter "test/"
   add_filter "vendor/"


### PR DESCRIPTION
This PR adds the `coveralls` gem, to try publishing coverage data, to power the status badge in the README.

Documentation used: https://docs.coveralls.io/ruby-on-rails