### PR TITLE
eIDAS SAML extensions including SPType and RequestedAttribute/RequestedAttributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ test/Test.iml
 *.gem
 .bundle
 *.patch
+/vendor

--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -179,7 +179,7 @@ module OneLogin
           eidas_sptype = req_extensions.add_element 'eidas:SPType'
           eidas_sptype.text = sptype_value
 
-          unless settings.extensions[:requested_attributes].empty?
+          if settings.extensions[:requested_attributes].respond_to? :each
             req_attributes = req_extensions.add_element 'eidas:RequestedAttributes'
             settings.extensions[:requested_attributes].each do |requested_attr|
               next unless requested_attr.is_a? RequestedAttribute

--- a/lib/onelogin/ruby-saml/requested_attribute.rb
+++ b/lib/onelogin/ruby-saml/requested_attribute.rb
@@ -1,0 +1,42 @@
+module OneLogin
+  module RubySaml
+
+    # Class simplifying management of eidas:RequestedAttribute from eIDAS saml-extensions
+    # It's implementation is intentionally vague to allow custom attributes of RequestedAttribute element and accept any kind of value
+    class RequestedAttribute
+
+      attr_accessor :attributes
+      attr_accessor :value
+
+      DEFAULTS = {
+          :NameFormat => 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri'.freeze,
+          :isRequired => false,
+          :FriendlyName => false
+      }.freeze
+
+      # @param attrs [Hash] The +attrs+ must be Hash of known attributes, ie:
+      #   RequestedAttribute.new({
+      #     :Name => "http://eidas.europa.eu/attributes/naturalperson/DateOfBirth",
+      #     :FriendlyName => "DoB",
+      #     :isRequired => false,
+      #     :NameFormat => "urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+      #   })
+      # or if above mentioned defaults suit your needs, you can provide only RequestedAttribute Name
+      #   RequestedAttribute.new({
+      #     :Name = "http://www.stork.gov.eu/1.0/isAgeOver"
+      #  }, 18)
+      # @param [String|Object] val value of eidas:AttributeValue or nil if you don't want the element to be provided
+      def initialize(attrs = {}, val = nil)
+        @attributes = DEFAULTS.merge(attrs)
+        @value = val
+      end
+
+      # @return [Hash]
+      def stringify_attribute_keys
+        Hash[attributes.collect { |k, v| [k.to_s, v] }]
+      end
+
+    end
+
+  end
+end

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -10,16 +10,18 @@ module OneLogin
     # SAML2 Toolkit Settings
     #
     class Settings
-      def initialize(overrides = {}, keep_security_attributes = false)
+      def initialize(overrides = {}, keep_security_attributes = false, keep_extensions_attributes = true)
+        config = DEFAULTS.merge(overrides)
         if keep_security_attributes
           security_attributes = overrides.delete(:security) || {}
-          config = DEFAULTS.merge(overrides)
           config[:security] = DEFAULTS[:security].merge(security_attributes)
-        else
-          config = DEFAULTS.merge(overrides)
+        end
+        if keep_extensions_attributes
+          extensions_attributes = overrides.delete(:extensions) || {}
+          config[:extensions] = DEFAULTS[:extensions].merge(extensions_attributes)
         end
 
-        config.each do |k,v|
+        config.each do |k, v|
           acc = "#{k.to_s}=".to_sym
           if respond_to? acc
             value = v.is_a?(Hash) ? v.dup : v
@@ -69,6 +71,8 @@ module OneLogin
       attr_accessor :assertion_consumer_logout_service_url
       attr_accessor :assertion_consumer_logout_service_binding
       attr_accessor :issuer
+      # EIDAS / samlp:Extensions
+      attr_accessor :extensions
 
       # @return [String] SP Entity ID
       #
@@ -164,7 +168,7 @@ module OneLogin
 
         raise ArgumentError.new("Invalid value for idp_cert_multi") if not idp_cert_multi.is_a?(Hash)
 
-        certs = {:signing => [], :encryption => [] }
+        certs = {:signing => [], :encryption => []}
 
         if idp_cert_multi.key?(:signing) and not idp_cert_multi[:signing].empty?
           idp_cert_multi[:signing].each do |idp_cert|
@@ -221,27 +225,31 @@ module OneLogin
       private
 
       DEFAULTS = {
-        :assertion_consumer_service_binding        => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST".freeze,
-        :single_logout_service_binding             => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect".freeze,
-        :idp_cert_fingerprint_algorithm            => XMLSecurity::Document::SHA1,
-        :compress_request                          => true,
-        :compress_response                         => true,
-        :soft                                      => true,
-        :double_quote_xml_attribute_values         => false,
-        :security                                  => {
-          :authn_requests_signed      => false,
-          :logout_requests_signed     => false,
-          :logout_responses_signed    => false,
-          :want_assertions_signed     => false,
-          :want_assertions_encrypted  => false,
-          :want_name_id               => false,
-          :metadata_signed            => false,
-          :embed_sign                 => false,
-          :digest_method              => XMLSecurity::Document::SHA1,
-          :signature_method           => XMLSecurity::Document::RSA_SHA1,
-          :check_idp_cert_expiration  => false,
-          :check_sp_cert_expiration   => false
-        }.freeze
+          :assertion_consumer_service_binding => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST".freeze,
+          :single_logout_service_binding => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect".freeze,
+          :idp_cert_fingerprint_algorithm => XMLSecurity::Document::SHA1,
+          :compress_request => true,
+          :compress_response => true,
+          :soft => true,
+          :double_quote_xml_attribute_values => false,
+          :extensions => {
+              :sptype => false,
+              :requested_attributes => false
+          }.freeze,
+          :security => {
+              :authn_requests_signed => false,
+              :logout_requests_signed => false,
+              :logout_responses_signed => false,
+              :want_assertions_signed => false,
+              :want_assertions_encrypted => false,
+              :want_name_id => false,
+              :metadata_signed => false,
+              :embed_sign => false,
+              :digest_method => XMLSecurity::Document::SHA1,
+              :signature_method => XMLSecurity::Document::RSA_SHA1,
+              :check_idp_cert_expiration => false,
+              :check_sp_cert_expiration => false
+          }.freeze
       }.freeze
     end
   end

--- a/lib/schemas/CoreVocabularies-AggregateComponents-1.1.xsd
+++ b/lib/schemas/CoreVocabularies-AggregateComponents-1.1.xsd
@@ -1,0 +1,1703 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           ISA Core Vocabularies 1.1 BETA
+                     https://joinup.ec.europa.eu/asset/core_vocabularies/description
+  Module:            xsd/CoreVocabularies-AggregateComponents-1.1.xsd
+  Generated on:      2015-02-03 07:46z
+-->
+<xsd:schema xmlns="http://www.w3.org/ns/corevocabulary/AggregateComponents"
+            xmlns:cva="http://www.w3.org/ns/corevocabulary/AggregateComponents"
+            xmlns:cvb="http://www.w3.org/ns/corevocabulary/BasicComponents"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:ccts="urn:un:unece:uncefact:documentation:2"
+            targetNamespace="http://www.w3.org/ns/corevocabulary/AggregateComponents"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="1.91">
+   <!-- ===== Imports ===== -->
+   <xsd:import namespace="http://www.w3.org/ns/corevocabulary/BasicComponents"
+               schemaLocation="CoreVocabularies-BasicComponents-1.1.xsd"/>
+   <!-- ===== Element Declarations ===== -->
+   <xsd:element name="Agent" type="AgentType"/>
+   <xsd:element name="AgentPlaysRoleCorePublicService" type="CorePublicServiceType"/>
+   <xsd:element name="AgentProvidesCorePublicService" type="CorePublicServiceType"/>
+   <xsd:element name="AgentUsesCorePublicService" type="CorePublicServiceType"/>
+   <xsd:element name="Channel" type="ChannelType"/>
+   <xsd:element name="CoreAddress" type="CoreAddressType"/>
+   <xsd:element name="CoreBusiness" type="CoreBusinessType"/>
+   <xsd:element name="CoreLocation" type="CoreLocationType"/>
+   <xsd:element name="CorePerson" type="CorePersonType"/>
+   <xsd:element name="CorePublicService" type="CorePublicServiceType"/>
+   <xsd:element name="CreatorAgent" type="AgentType"/>
+   <xsd:element name="FormalFramework" type="FormalFrameworkType"/>
+   <xsd:element name="Geometry" type="GeometryType"/>
+   <xsd:element name="ImplementsFormalFramework" type="FormalFrameworkType"/>
+   <xsd:element name="Input" type="InputType"/>
+   <xsd:element name="Jurisdiction" type="JurisdictionType"/>
+   <xsd:element name="LegalEntityCoreAddress" type="CoreAddressType"/>
+   <xsd:element name="LegalEntityCoreLocation" type="CoreLocationType"/>
+   <xsd:element name="LocationCoreAddress" type="CoreAddressType"/>
+   <xsd:element name="LocationGeometry" type="GeometryType"/>
+   <xsd:element name="Output" type="OutputType"/>
+   <xsd:element name="PeriodOfTime" type="PeriodOfTimeType"/>
+   <xsd:element name="PersonCitizenshipJurisdiction" type="JurisdictionType"/>
+   <xsd:element name="PersonCoreAddress" type="CoreAddressType"/>
+   <xsd:element name="PersonCountryOfBirthCoreLocation" type="CoreLocationType"/>
+   <xsd:element name="PersonCountryOfDeathCoreLocation" type="CoreLocationType"/>
+   <xsd:element name="PersonPlaceOfBirthCoreLocation" type="CoreLocationType"/>
+   <xsd:element name="PersonPlaceOfDeathCoreLocation" type="CoreLocationType"/>
+   <xsd:element name="PersonResidencyJurisdiction" type="JurisdictionType"/>
+   <xsd:element name="PublicServiceChannel" type="ChannelType"/>
+   <xsd:element name="PublicServiceFollowsRule" type="RuleType"/>
+   <xsd:element name="PublicServiceInput" type="InputType"/>
+   <xsd:element name="PublicServicePhysicallyAvailableAtCoreLocation"
+                type="CoreLocationType"/>
+   <xsd:element name="PublicServiceProducesOutput" type="OutputType"/>
+   <xsd:element name="PublicServiceSpatialCoreLocation" type="CoreLocationType"/>
+   <xsd:element name="PublicServiceTemporalPeriodOfTime" type="PeriodOfTimeType"/>
+   <xsd:element name="RegisteredCoreAddress" type="CoreAddressType"/>
+   <xsd:element name="RelatedCorePublicService" type="CorePublicServiceType"/>
+   <xsd:element name="RelatedFormalFramework" type="FormalFrameworkType"/>
+   <xsd:element name="RequiresCorePublicService" type="CorePublicServiceType"/>
+   <xsd:element name="Rule" type="RuleType"/>
+   <!-- ===== Type Definitions ===== -->
+   <!-- ===== Aggregate Business Information Entity Type Definitions ===== -->
+   <xsd:complexType name="AgentType">
+      <xsd:annotation>
+         <xsd:documentation>
+            <ccts:Component>
+               <ccts:ComponentType>ABIE</ccts:ComponentType>
+               <ccts:DictionaryEntryName>Agent. Details</ccts:DictionaryEntryName>
+               <ccts:Definition>An entity that is able to carry out actions.</ccts:Definition>
+               <ccts:ObjectClass>Agent</ccts:ObjectClass>
+            </ccts:Component>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="AgentPlaysRoleCorePublicService" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Agent. Agent Plays Role_ Core Public Service. Core Public Service</ccts:DictionaryEntryName>
+                     <ccts:Definition>A public service in which the agent plays a role.</ccts:Definition>
+                     <ccts:Cardinality>0..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Agent</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Agent Plays Role</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Core Public Service</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Core Public Service</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Core Public Service</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="AgentProvidesCorePublicService" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Agent. Agent Provides_ Core Public Service. Core Public Service</ccts:DictionaryEntryName>
+                     <ccts:Definition>A public service provided by the agent.</ccts:Definition>
+                     <ccts:Cardinality>0..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Agent</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Agent Provides</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Core Public Service</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Core Public Service</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Core Public Service</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="AgentUsesCorePublicService" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Agent. Agent Uses_ Core Public Service. Core Public Service</ccts:DictionaryEntryName>
+                     <ccts:Definition>A public service used by the agent.</ccts:Definition>
+                     <ccts:Cardinality>0..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Agent</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Agent Uses</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Core Public Service</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Core Public Service</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Core Public Service</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ChannelType">
+      <xsd:annotation>
+         <xsd:documentation>
+            <ccts:Component>
+               <ccts:ComponentType>ABIE</ccts:ComponentType>
+               <ccts:DictionaryEntryName>Channel. Details</ccts:DictionaryEntryName>
+               <ccts:Definition>A medium through which an agent provides, uses or otherwise interacts with a resource.</ccts:Definition>
+               <ccts:ObjectClass>Channel</ccts:ObjectClass>
+            </ccts:Component>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="cvb:ChannelID" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Channel. Channel_ Identifier. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identifier of the channel.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Channel</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Channel</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Identifier</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Identifier</ccts:RepresentationTerm>
+                     <ccts:DataType>Identifier. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CoreAddressType">
+      <xsd:annotation>
+         <xsd:documentation>
+            <ccts:Component>
+               <ccts:ComponentType>ABIE</ccts:ComponentType>
+               <ccts:DictionaryEntryName>Core Address. Details</ccts:DictionaryEntryName>
+               <ccts:Definition>An address representing a location.</ccts:Definition>
+               <ccts:ObjectClass>Core Address</ccts:ObjectClass>
+            </ccts:Component>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="cvb:AddressFullAddress" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Address. Address_ Full Address. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The complete address with or without formatting.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Address</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Address</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Full Address</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Text</ccts:RepresentationTerm>
+                     <ccts:DataType>Text. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:AddressPostOfficeBox" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Address. Address_ Post Office Box. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The Post Office Box number.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Address</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Address</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Post Office Box</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Text</ccts:RepresentationTerm>
+                     <ccts:DataType>Text. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:AddressThoroughfare" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Address. Address_ Thoroughfare. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of a passage or way through from one location to another.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Address</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Address</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Thoroughfare</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Text</ccts:RepresentationTerm>
+                     <ccts:DataType>Text. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:AddressLocatorDesignator"
+                      minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Address. Address_ Locator Designator. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>A number or a sequence of characters that uniquely identifies the locator within the relevant scope.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Address</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Address</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Locator Designator</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Text</ccts:RepresentationTerm>
+                     <ccts:DataType>Text. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:AddressLocatorName" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Address. Address_ Locator Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>A proper noun applied to the real world entity identified by the address.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Address</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Address</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Locator Name</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Text</ccts:RepresentationTerm>
+                     <ccts:DataType>Text. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:AddressAddressArea" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Address. Address_ Address Area. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of a geographic area or locality that groups a number of addressable objects for addressing purposes, without being an administrative unit.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Address</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Address</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Address Area</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Text</ccts:RepresentationTerm>
+                     <ccts:DataType>Text. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:AddressPostName" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Address. Address_ Post Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The key postal division of the address, usually the city.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Address</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Address</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Post Name</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Text</ccts:RepresentationTerm>
+                     <ccts:DataType>Text. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:AddressAdminUnitLocationTwo"
+                      minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Address. Address_ Admin Unit Location Two. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The region of the address, usually a county, state or other such area that typically encompasses several localities.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Address</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Address</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Admin Unit Location Two</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Text</ccts:RepresentationTerm>
+                     <ccts:DataType>Text. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:AddressAdminUnitLocationOne"
+                      minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Address. Address_ Admin Unit Location One. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The uppermost administrative unit for the address, almost always a country.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Address</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Address</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Admin Unit Location One</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Text</ccts:RepresentationTerm>
+                     <ccts:DataType>Text. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:AddressPostCode" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Address. Address_ Post Code. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The post code, a.k.a. postal code, ZIP code, etc.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Address</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Address</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Post Code</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Text</ccts:RepresentationTerm>
+                     <ccts:DataType>Text. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:AddressID" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Address. Address_ Identifier. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>A globally unique identifier for this instance of the address.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Address</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Address</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Identifier</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Identifier</ccts:RepresentationTerm>
+                     <ccts:DataType>Identifier. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CoreBusinessType">
+      <xsd:annotation>
+         <xsd:documentation>
+            <ccts:Component>
+               <ccts:ComponentType>ABIE</ccts:ComponentType>
+               <ccts:DictionaryEntryName>Core Business. Details</ccts:DictionaryEntryName>
+               <ccts:Definition>A business that is legally registered.</ccts:Definition>
+               <ccts:ObjectClass>Core Business</ccts:ObjectClass>
+            </ccts:Component>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="cvb:LegalEntityLegalID" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Business. Legal Entity_ Legal Identifier. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identifier given to the legal entity by the authority with which it is registered.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Business</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Legal Entity</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Legal Identifier</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Identifier</ccts:RepresentationTerm>
+                     <ccts:DataType>Identifier. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:LegalEntityID" minOccurs="1" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Business. Legal Entity_ Identifier. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>A formally-issued identifier for the legal entity, other than the one that confers legal status upon it.</ccts:Definition>
+                     <ccts:Cardinality>1..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Business</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Legal Entity</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Identifier</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Identifier</ccts:RepresentationTerm>
+                     <ccts:DataType>Identifier. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:LegalEntityLegalName" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Business. Legal Entity_ Legal Name. Name</ccts:DictionaryEntryName>
+                     <ccts:Definition>The legal name of the business.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Business</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Legal Entity</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Legal Name</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Name</ccts:RepresentationTerm>
+                     <ccts:DataType>Name. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:LegalEntityAlternativeName"
+                      minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Business. Legal Entity_ Alternative Name. Name</ccts:DictionaryEntryName>
+                     <ccts:Definition>A recognized name other than the legal name.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Business</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Legal Entity</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Alternative Name</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Name</ccts:RepresentationTerm>
+                     <ccts:DataType>Name. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:LegalEntityCompanyTypeCode" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Business. Legal Entity_ Company Type Code. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The type of the business.</ccts:Definition>
+                     <ccts:Cardinality>0..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Business</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Legal Entity</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Company Type Code</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Code</ccts:RepresentationTerm>
+                     <ccts:DataType>Code. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:LegalEntityCompanyStatusCode" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Business. Legal Entity_ Company Status Code. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The status of the business.</ccts:Definition>
+                     <ccts:Cardinality>0..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Business</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Legal Entity</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Company Status Code</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Code</ccts:RepresentationTerm>
+                     <ccts:DataType>Code. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:LegalEntityCompanyActivityCode"
+                      minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Business. Legal Entity_ Company Activity Code. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The activity of the business.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Business</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Legal Entity</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Company Activity Code</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Code</ccts:RepresentationTerm>
+                     <ccts:DataType>Code. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="RegisteredCoreAddress" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Business. Registered_ Core Address. Core Address</ccts:DictionaryEntryName>
+                     <ccts:Definition>The registered address of the business.</ccts:Definition>
+                     <ccts:Cardinality>0..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Business</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Registered</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Core Address</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Core Address</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Core Address</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="LegalEntityCoreAddress" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Business. Legal Entity_ Core Address. Core Address</ccts:DictionaryEntryName>
+                     <ccts:Definition>An address related to the business, other than the registered address.</ccts:Definition>
+                     <ccts:Cardinality>0..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Business</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Legal Entity</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Core Address</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Core Address</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Core Address</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="LegalEntityCoreLocation" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Business. Legal Entity_ Core Location. Core Location</ccts:DictionaryEntryName>
+                     <ccts:Definition>A location related to the business.</ccts:Definition>
+                     <ccts:Cardinality>0..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Business</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Legal Entity</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Core Location</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Core Location</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Core Location</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CoreLocationType">
+      <xsd:annotation>
+         <xsd:documentation>
+            <ccts:Component>
+               <ccts:ComponentType>ABIE</ccts:ComponentType>
+               <ccts:DictionaryEntryName>Core Location. Details</ccts:DictionaryEntryName>
+               <ccts:Definition>An identifiable geographic place.</ccts:Definition>
+               <ccts:ObjectClass>Core Location</ccts:ObjectClass>
+            </ccts:Component>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="cvb:LocationGeographicName" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Location. Location Geographic_ Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>A proper noun applied to a spatial object.</ccts:Definition>
+                     <ccts:Cardinality>0..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Location</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Location Geographic</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Name</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Text</ccts:RepresentationTerm>
+                     <ccts:DataType>Text. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:LocationGeographicID" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Location. Location Geographic_ Identifier. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>A URI that identifies the location.</ccts:Definition>
+                     <ccts:Cardinality>0..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Location</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Location Geographic</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Identifier</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Identifier</ccts:RepresentationTerm>
+                     <ccts:DataType>Identifier. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="LocationCoreAddress" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Location. Location_ Core Address. Core Address</ccts:DictionaryEntryName>
+                     <ccts:Definition>An address representing the location.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Location</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Location</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Core Address</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Core Address</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Core Address</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="LocationGeometry" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Location. Location_ Geometry. Geometry</ccts:DictionaryEntryName>
+                     <ccts:Definition>A geometry representing the location.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Location</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Location</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Geometry</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Geometry</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Geometry</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CorePersonType">
+      <xsd:annotation>
+         <xsd:documentation>
+            <ccts:Component>
+               <ccts:ComponentType>ABIE</ccts:ComponentType>
+               <ccts:DictionaryEntryName>Core Person. Details</ccts:DictionaryEntryName>
+               <ccts:Definition>A natural person.</ccts:Definition>
+               <ccts:ObjectClass>Core Person</ccts:ObjectClass>
+            </ccts:Component>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="cvb:PersonID" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Person. Person Identifier. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>A formally-issued identifier for the person.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Person</ccts:ObjectClass>
+                     <ccts:PropertyTerm>Person Identifier</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Identifier</ccts:RepresentationTerm>
+                     <ccts:DataType>Identifier. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:PersonFullName" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Person. Person_ Full Name. Name</ccts:DictionaryEntryName>
+                     <ccts:Definition>The complete name of the person as one string.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Person</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Person</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Full Name</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Name</ccts:RepresentationTerm>
+                     <ccts:DataType>Name. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:PersonFamilyName" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Person. Person_ Family Name. Name</ccts:DictionaryEntryName>
+                     <ccts:Definition>The denominator(s) that identify the person within a family.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Person</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Person</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Family Name</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Name</ccts:RepresentationTerm>
+                     <ccts:DataType>Name. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:PersonGivenName" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Person. Person_ Given Name. Name</ccts:DictionaryEntryName>
+                     <ccts:Definition>A name that is usually shared by members of a family.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Person</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Person</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Given Name</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Name</ccts:RepresentationTerm>
+                     <ccts:DataType>Name. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:PersonPatronymicName" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Person. Person_ Patronymic Name. Name</ccts:DictionaryEntryName>
+                     <ccts:Definition>A name referring to the father's given name.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Person</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Person</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Patronymic Name</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Name</ccts:RepresentationTerm>
+                     <ccts:DataType>Name. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:PersonAlternativeName" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Person. Person_ Alternative Name. Name</ccts:DictionaryEntryName>
+                     <ccts:Definition>A name by which the person is known other than her given name and/or full name.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Person</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Person</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Alternative Name</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Name</ccts:RepresentationTerm>
+                     <ccts:DataType>Name. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:PersonGenderCode" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Person. Person_ Gender Code. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The gender of the person.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Person</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Person</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Gender Code</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Code</ccts:RepresentationTerm>
+                     <ccts:DataType>Code. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:PersonBirthName" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Person. Person_ Birth Name. Name</ccts:DictionaryEntryName>
+                     <ccts:Definition>The full name of the person at the time of her birth, irrespective of any subsequent changes.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Person</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Person</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Birth Name</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Name</ccts:RepresentationTerm>
+                     <ccts:DataType>Name. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:PersonBirthDate" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Person. Person_ Birth Date. Date</ccts:DictionaryEntryName>
+                     <ccts:Definition>The date on which the person was born.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Person</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Person</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Birth Date</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Date</ccts:RepresentationTerm>
+                     <ccts:DataType>Date. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:PersonDeathDate" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Person. Person_ Death Date. Date</ccts:DictionaryEntryName>
+                     <ccts:Definition>The date on which the person deceased.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Person</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Person</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Death Date</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Date</ccts:RepresentationTerm>
+                     <ccts:DataType>Date. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="PersonCountryOfBirthCoreLocation"
+                      minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Person. Person Country Of Birth_ Core Location. Core Location</ccts:DictionaryEntryName>
+                     <ccts:Definition>The country where the person was born.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Person</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Person Country Of Birth</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Core Location</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Core Location</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Core Location</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="PersonCountryOfDeathCoreLocation"
+                      minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Person. Person Country Of Death_ Core Location. Core Location</ccts:DictionaryEntryName>
+                     <ccts:Definition>The country where the person deceased.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Person</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Person Country Of Death</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Core Location</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Core Location</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Core Location</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="PersonPlaceOfBirthCoreLocation"
+                      minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Person. Person Place Of Birth_ Core Location. Core Location</ccts:DictionaryEntryName>
+                     <ccts:Definition>The location where the person was born.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Person</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Person Place Of Birth</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Core Location</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Core Location</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Core Location</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="PersonPlaceOfDeathCoreLocation"
+                      minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Person. Person Place Of Death_ Core Location. Core Location</ccts:DictionaryEntryName>
+                     <ccts:Definition>The location where the person deceased.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Person</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Person Place Of Death</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Core Location</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Core Location</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Core Location</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="PersonCitizenshipJurisdiction"
+                      minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Person. Person Citizenship_ Jurisdiction. Jurisdiction</ccts:DictionaryEntryName>
+                     <ccts:Definition>The jurisdiction that has conferred citizenship rights on the person.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Person</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Person Citizenship</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Jurisdiction</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Jurisdiction</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Jurisdiction</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="PersonResidencyJurisdiction"
+                      minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Person. Person Residency_ Jurisdiction. Jurisdiction</ccts:DictionaryEntryName>
+                     <ccts:Definition>The jurisdiction in which the person resides, typically providing the person with a subset of the rights of a citizen.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Person</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Person Residency</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Jurisdiction</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Jurisdiction</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Jurisdiction</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="PersonCoreAddress" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Person. Person_ Core Address. Core Address</ccts:DictionaryEntryName>
+                     <ccts:Definition>An address related to the person.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Person</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Person</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Core Address</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Core Address</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Core Address</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CorePublicServiceType">
+      <xsd:annotation>
+         <xsd:documentation>
+            <ccts:Component>
+               <ccts:ComponentType>ABIE</ccts:ComponentType>
+               <ccts:DictionaryEntryName>Core Public Service. Details</ccts:DictionaryEntryName>
+               <ccts:Definition>A set of deeds and acts performed by or on behalf of a public agency for the benefit of a citizen, a business or another public agency.</ccts:Definition>
+               <ccts:ObjectClass>Core Public Service</ccts:ObjectClass>
+            </ccts:Component>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="cvb:PublicServiceName" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Public Service. Public Service Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of the service.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Public Service</ccts:ObjectClass>
+                     <ccts:PropertyTerm>Public Service Name</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Text</ccts:RepresentationTerm>
+                     <ccts:DataType>Text. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:PublicServiceDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Public Service. Public Service Description. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>A free text description of the service.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Public Service</ccts:ObjectClass>
+                     <ccts:PropertyTerm>Public Service Description</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Text</ccts:RepresentationTerm>
+                     <ccts:DataType>Text. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:PublicServiceTypeCode" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Public Service. Public Service Type. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The type of service.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Public Service</ccts:ObjectClass>
+                     <ccts:PropertyTerm>Public Service Type</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Code</ccts:RepresentationTerm>
+                     <ccts:DataType>Code. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:PublicServiceLanguageCode"
+                      minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Public Service. Public Service Language. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The language(s) in which the service is available.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Public Service</ccts:ObjectClass>
+                     <ccts:PropertyTerm>Public Service Language</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Code</ccts:RepresentationTerm>
+                     <ccts:DataType>Code. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:PublicServiceHomepageID"
+                      minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Public Service. Public Service Homepage. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The Web page through which the service may be available.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Public Service</ccts:ObjectClass>
+                     <ccts:PropertyTerm>Public Service Homepage</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Identifier</ccts:RepresentationTerm>
+                     <ccts:DataType>Identifier. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="PublicServiceChannel" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Public Service. Public Service_ Channel. Channel</ccts:DictionaryEntryName>
+                     <ccts:Definition>A medium through which an agent interacts with the service.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Public Service</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Public Service</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Channel</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Channel</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Channel</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="PublicServicePhysicallyAvailableAtCoreLocation"
+                      minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Public Service. Public Service Physically Available At_ Core Location. Core Location</ccts:DictionaryEntryName>
+                     <ccts:Definition>A physical location at which a user may interact with the service.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Public Service</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Public Service Physically Available At</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Core Location</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Core Location</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Core Location</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="RequiresCorePublicService" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Public Service. Requires_ Core Public Service. Core Public Service</ccts:DictionaryEntryName>
+                     <ccts:Definition>Another public service required by this service.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Public Service</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Requires</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Core Public Service</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Core Public Service</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Core Public Service</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="RelatedCorePublicService" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Public Service. Related_ Core Public Service. Core Public Service</ccts:DictionaryEntryName>
+                     <ccts:Definition>Another public service related to this service, without being required by this service.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Public Service</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Related</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Core Public Service</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Core Public Service</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Core Public Service</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="PublicServiceInput" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Public Service. Public Service_ Input. Input</ccts:DictionaryEntryName>
+                     <ccts:Definition>A resource required by the service in order to operate.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Public Service</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Public Service</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Input</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Input</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Input</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="PublicServiceProducesOutput"
+                      minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Public Service. Public Service Produces_ Output. Output</ccts:DictionaryEntryName>
+                     <ccts:Definition>A resource produced by the service.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Public Service</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Public Service Produces</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Output</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Output</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Output</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="PublicServiceFollowsRule" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Public Service. Public Service Follows_ Rule. Rule</ccts:DictionaryEntryName>
+                     <ccts:Definition>A rule under which the public service operates.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Public Service</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Public Service Follows</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Rule</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Rule</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Rule</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="PublicServiceSpatialCoreLocation"
+                      minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Public Service. Public Service Spatial_ Core Location. Core Location</ccts:DictionaryEntryName>
+                     <ccts:Definition>The area in which the service is available.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Public Service</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Public Service Spatial</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Core Location</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Core Location</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Core Location</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="PublicServiceTemporalPeriodOfTime"
+                      minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Core Public Service. Public Service Temporal_ Period Of Time. Period Of Time</ccts:DictionaryEntryName>
+                     <ccts:Definition>The time frame in which the service is available.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Core Public Service</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Public Service Temporal</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Period Of Time</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Period Of Time</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Period Of Time</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FormalFrameworkType">
+      <xsd:annotation>
+         <xsd:documentation>
+            <ccts:Component>
+               <ccts:ComponentType>ABIE</ccts:ComponentType>
+               <ccts:DictionaryEntryName>Formal Framework. Details</ccts:DictionaryEntryName>
+               <ccts:Definition>Legislation, policy, or policies lying behind the rules that govern a public service.</ccts:Definition>
+               <ccts:ObjectClass>Formal Framework</ccts:ObjectClass>
+            </ccts:Component>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="CreatorAgent" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Formal Framework. Creator_ Agent. Agent</ccts:DictionaryEntryName>
+                     <ccts:Definition>The public body responsible for the formal framework.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Formal Framework</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Creator</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Agent</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Agent</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Agent</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="RelatedFormalFramework" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Formal Framework. Related_ Formal Framework. Formal Framework</ccts:DictionaryEntryName>
+                     <ccts:Definition>A formal framework related to this framework.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Formal Framework</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Related</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Formal Framework</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Formal Framework</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Formal Framework</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="GeometryType">
+      <xsd:annotation>
+         <xsd:documentation>
+            <ccts:Component>
+               <ccts:ComponentType>ABIE</ccts:ComponentType>
+               <ccts:DictionaryEntryName>Geometry. Details</ccts:DictionaryEntryName>
+               <ccts:Definition>A geometry representing a location.</ccts:Definition>
+               <ccts:ObjectClass>Geometry</ccts:ObjectClass>
+            </ccts:Component>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="cvb:GeometryCoordinateReferenceSystemID"
+                      minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Geometry. Geometry Coordinate Reference System. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The Coordinate Reference System (CRS) used to encode the coordinates.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Geometry</ccts:ObjectClass>
+                     <ccts:PropertyTerm>Geometry Coordinate Reference System</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Identifier</ccts:RepresentationTerm>
+                     <ccts:DataType>Identifier. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:GeometryTypeCode" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Geometry. Geometry Type. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The type of the geometry.</ccts:Definition>
+                     <ccts:Cardinality>0..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Geometry</ccts:ObjectClass>
+                     <ccts:PropertyTerm>Geometry Type</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Code</ccts:RepresentationTerm>
+                     <ccts:DataType>Code. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:GeometryCoordinates" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Geometry. Geometry Coordinates. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The ordered list of coordinates of the geometry.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Geometry</ccts:ObjectClass>
+                     <ccts:PropertyTerm>Geometry Coordinates</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Text</ccts:RepresentationTerm>
+                     <ccts:DataType>Text. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="InputType">
+      <xsd:annotation>
+         <xsd:documentation>
+            <ccts:Component>
+               <ccts:ComponentType>ABIE</ccts:ComponentType>
+               <ccts:DictionaryEntryName>Input. Details</ccts:DictionaryEntryName>
+               <ccts:Definition>A resource to be processed to produce an output.</ccts:Definition>
+               <ccts:ObjectClass>Input</ccts:ObjectClass>
+            </ccts:Component>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="cvb:InputName" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Input. Input_ Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of the input.</ccts:Definition>
+                     <ccts:Cardinality>0..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Input</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Input</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Name</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Text</ccts:RepresentationTerm>
+                     <ccts:DataType>Text. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:InputDescription" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Input. Input_ Description. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>A free text description of the input.</ccts:Definition>
+                     <ccts:Cardinality>0..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Input</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Input</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Description</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Text</ccts:RepresentationTerm>
+                     <ccts:DataType>Text. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:InputTypeCode" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Input. Input_ Type. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The type of the input.</ccts:Definition>
+                     <ccts:Cardinality>0..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Input</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Input</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Type</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Code</ccts:RepresentationTerm>
+                     <ccts:DataType>Code. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="JurisdictionType">
+      <xsd:annotation>
+         <xsd:documentation>
+            <ccts:Component>
+               <ccts:ComponentType>ABIE</ccts:ComponentType>
+               <ccts:DictionaryEntryName>Jurisdiction. Details</ccts:DictionaryEntryName>
+               <ccts:Definition>A jurisdiction, typically a country, dealing with and making pronouncements on legal matters.</ccts:Definition>
+               <ccts:ObjectClass>Jurisdiction</ccts:ObjectClass>
+            </ccts:Component>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="cvb:JurisdictionID" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Jurisdiction. Jurisdiction Identifier. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The URI for the jurisdiction.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Jurisdiction</ccts:ObjectClass>
+                     <ccts:PropertyTerm>Jurisdiction Identifier</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Identifier</ccts:RepresentationTerm>
+                     <ccts:DataType>Identifier. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:JurisdictionName" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Jurisdiction. Jurisdiction Name. Name</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of the jurisdiction.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Jurisdiction</ccts:ObjectClass>
+                     <ccts:PropertyTerm>Jurisdiction Name</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Name</ccts:RepresentationTerm>
+                     <ccts:DataType>Name. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OutputType">
+      <xsd:annotation>
+         <xsd:documentation>
+            <ccts:Component>
+               <ccts:ComponentType>ABIE</ccts:ComponentType>
+               <ccts:DictionaryEntryName>Output. Details</ccts:DictionaryEntryName>
+               <ccts:Definition>An intended result whose required inputs and processes are entirely within the control of the planning organisation.</ccts:Definition>
+               <ccts:ObjectClass>Output</ccts:ObjectClass>
+            </ccts:Component>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="cvb:OutputName" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Output. Output_ Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of the output.</ccts:Definition>
+                     <ccts:Cardinality>0..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Output</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Output</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Name</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Text</ccts:RepresentationTerm>
+                     <ccts:DataType>Text. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:OutputDescription" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Output. Output_ Description. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>A free text description of the output.</ccts:Definition>
+                     <ccts:Cardinality>0..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Output</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Output</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Description</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Text</ccts:RepresentationTerm>
+                     <ccts:DataType>Text. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:OutputTypeCode" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Output. Output_ Type. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The type of the output.</ccts:Definition>
+                     <ccts:Cardinality>0..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Output</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Output</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Type</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Code</ccts:RepresentationTerm>
+                     <ccts:DataType>Code. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PeriodOfTimeType">
+      <xsd:annotation>
+         <xsd:documentation>
+            <ccts:Component>
+               <ccts:ComponentType>ABIE</ccts:ComponentType>
+               <ccts:DictionaryEntryName>Period Of Time. Details</ccts:DictionaryEntryName>
+               <ccts:Definition>An interval of time that is named or defined by its start and end dates.</ccts:Definition>
+               <ccts:ObjectClass>Period Of Time</ccts:ObjectClass>
+            </ccts:Component>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="cvb:PeriodOfTimeStartDate" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Period Of Time. Period Of Time_ Start Date. Date</ccts:DictionaryEntryName>
+                     <ccts:Definition>The start date of the period.</ccts:Definition>
+                     <ccts:Cardinality>0..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Period Of Time</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Period Of Time</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Start Date</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Date</ccts:RepresentationTerm>
+                     <ccts:DataType>Date. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="cvb:PeriodOfTimeEndDate" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Period Of Time. Period Of Time_ End Date. Date</ccts:DictionaryEntryName>
+                     <ccts:Definition>The end date of the period.</ccts:Definition>
+                     <ccts:Cardinality>0..1</ccts:Cardinality>
+                     <ccts:ObjectClass>Period Of Time</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Period Of Time</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>End Date</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Date</ccts:RepresentationTerm>
+                     <ccts:DataType>Date. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RuleType">
+      <xsd:annotation>
+         <xsd:documentation>
+            <ccts:Component>
+               <ccts:ComponentType>ABIE</ccts:ComponentType>
+               <ccts:DictionaryEntryName>Rule. Details</ccts:DictionaryEntryName>
+               <ccts:Definition>A document that sets out the specific rules, guidelines, or procedures that a public service follows.</ccts:Definition>
+               <ccts:ObjectClass>Rule</ccts:ObjectClass>
+            </ccts:Component>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="cvb:RuleID" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>BBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Rule. Rule Identifier. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>Identifier for the rule.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Rule</ccts:ObjectClass>
+                     <ccts:PropertyTerm>Rule Identifier</ccts:PropertyTerm>
+                     <ccts:RepresentationTerm>Identifier</ccts:RepresentationTerm>
+                     <ccts:DataType>Identifier. Type</ccts:DataType>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="CreatorAgent" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Rule. Creator_ Agent. Agent</ccts:DictionaryEntryName>
+                     <ccts:Definition>The organization that is responsible for the rule.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Rule</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Creator</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Agent</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Agent</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Agent</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="ImplementsFormalFramework" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  <ccts:Component>
+                     <ccts:ComponentType>ASBIE</ccts:ComponentType>
+                     <ccts:DictionaryEntryName>Rule. Implements_ Formal Framework. Formal Framework</ccts:DictionaryEntryName>
+                     <ccts:Definition>The formal framework under which the rule is defined.</ccts:Definition>
+                     <ccts:Cardinality>0..n</ccts:Cardinality>
+                     <ccts:ObjectClass>Rule</ccts:ObjectClass>
+                     <ccts:PropertyTermQualifier>Implements</ccts:PropertyTermQualifier>
+                     <ccts:PropertyTerm>Formal Framework</ccts:PropertyTerm>
+                     <ccts:AssociatedObjectClass>Formal Framework</ccts:AssociatedObjectClass>
+                     <ccts:RepresentationTerm>Formal Framework</ccts:RepresentationTerm>
+                  </ccts:Component>
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== --><!--
+  Copyright (c) European Union, 2014
+  Licensed under the ISA Open Metadata Licence
+
+  ISA Open Metadata Licence v1.1
+
+  1. Copyright
+
+  The Work (as defined below) is provided under the terms of this ISA 
+  Open Metadata Licence (this Licence, or later versions of this Licence 
+  published by the European Commission). The work is protected by 
+  copyright and/or other applicable law. Any use of the work other than 
+  as authorised under this Licence or copyright law is prohibited.
+
+  By exercising any rights to the work provided here, you accept and
+  agree to be bound by the terms of this Licence. The Owner (as defined
+  below) grants You the rights contained here in consideration of your
+  acceptance of such terms and conditions.
+
+  2. Definitions
+
+  The “Owner” is the European Union represented by the European 
+  Commission, which is the original licensor and/or controls the 
+  copyright and any other intellectual and industrial property rights 
+  related to the Work.
+
+  The “Work” is the information and/or data offered to You under this 
+  Licence, according to the “Copyright Notice”:
+
+      Copyright (c) European Union, YEAR
+      Licensed under the ISA Open Metadata Licence,
+      Original author: CONTRIBUTOR(s)
+
+  "You" means the natural or legal person, or body of persons corporate 
+  or incorporate, acquiring rights under this licence.
+
+  "Contributor" means the natural or legal person whose Work is, by 
+  agreement with the European Commission, provided under this Licence.
+
+  "Use" means doing any act which is restricted by copyright or database 
+  right, whether in the original medium or in any other medium, and 
+  includes without limitation distributing, copying, adapting, modifying 
+  as may be technically necessary to use it in a different mode or 
+  format. It includes "re-Use", meaning the use, communication to the 
+  public and/or distribution of the Works for purposes other than the 
+  initial purpose for which the Work was produced.
+
+  3. Rights
+
+  In accordance to Commission Decision 2011/833/EU, You are herewith 
+  granted a worldwide, royalty-free, perpetual, non-exclusive licence to 
+  Use and re-Use the Works and any modifications thereof for any 
+  commercial and non-commercial purpose allowed by the law and provided 
+  that the following conditions are met:
+    a) Distributions or communication to the public must retain the 
+       above Copyright Notice;
+    b) Distributions must retain the following “No Warranty” disclaimer;
+    c) Where possible and practical, distributions or communication to 
+       the public will provide a link to the Joinup platform;
+    d) Acts directed to mislead others or misrepresent the Work, its 
+       content or source are prohibited;
+    e) You will not use the name of the European Commission and that of 
+       its Contributor(s) to endorse or promote products and services 
+       derived from the Use of the Work without specific prior written 
+       permission.
+
+  4. No Warranty
+
+  EACH WORK IS PROVIDED "AS IS" WITHOUT REPRESENTATIONS, WARRANTIES, 
+  OBLIGATIONS AND LIABILITIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, TO 
+  THE FULL EXTENT PERMITTED BY LAW INCLUDING, BUT NOT LIMITED TO, ANY 
+  IMPLIED WARRANTY OF MERCHANTABILITY, INTEGRATION, SATISFACTORY QUALITY 
+  AND FITNESS FOR A PARTICULAR PURPOSE.
+
+  EXCEPT IN THE CASES OF WILFUL MISCONDUCT OR DAMAGES DIRECTLY CAUSED TO 
+  NATURAL PERSONS, NEITHER EUROPEAN UNION NOR ITS CONTRIBUTOR(S) WILL BE 
+  LIABLE FOR ANY INCIDENTAL, CONSEQUENTIAL, DIRECT OR INDIRECT DAMAGES 
+  INCLUDING BUT NOT LIMITED TO THE LOSS OF DATA, LOST PROFITS, OR ANY 
+  OTHER FINANCIAL LOSS ARISING FROM THE USE OF, OR INABILITY TO USE, 
+  EVEN IF THE EUROPEAN UNION HAS BEEN NOTIFIED OF THE POSSIBILITY OF 
+  SUCH LOSS, DAMAGES, CLAIMS OR COSTS OR FOR ANY CLAIM BY ANY THIRD 
+  PARTY. HOWEVER, THE LICENSOR WILL BE LIABLE UNDER STATUTORY PRODUCT 
+  LIABILITY LAWS AS FAR SUCH LAWS APPLY TO THE WORK.
+
+  5. Governing Law
+
+  This licence is governed by the laws of the jurisdiction in which the 
+  first Contributor listed in the Copyright Notice has its principal 
+  place of business, unless otherwise specified by this Contributor.
+-->

--- a/lib/schemas/CoreVocabularies-BasicComponents-1.1.xsd
+++ b/lib/schemas/CoreVocabularies-BasicComponents-1.1.xsd
@@ -1,0 +1,416 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           ISA Core Vocabularies 1.1 BETA
+                     https://joinup.ec.europa.eu/asset/core_vocabularies/description
+  Module:            xsd/CoreVocabularies-BasicComponents-1.1.xsd
+  Generated on:      2015-02-03 07:46z
+-->
+<xsd:schema xmlns="http://www.w3.org/ns/corevocabulary/BasicComponents"
+            xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://www.w3.org/ns/corevocabulary/BasicComponents"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="1.91">
+   <!-- ===== Imports ===== -->
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2"
+               schemaLocation="common/UBL-UnqualifiedDataTypes-2.1.xsd"/>
+   <!-- ===== Element Declarations ===== -->
+   <xsd:element name="AddressAddressArea" type="AddressAddressAreaType"/>
+   <xsd:element name="AddressAdminUnitLocationOne"
+                type="AddressAdminUnitLocationOneType"/>
+   <xsd:element name="AddressAdminUnitLocationTwo"
+                type="AddressAdminUnitLocationTwoType"/>
+   <xsd:element name="AddressFullAddress" type="AddressFullAddressType"/>
+   <xsd:element name="AddressID" type="AddressIDType"/>
+   <xsd:element name="AddressLocatorDesignator" type="AddressLocatorDesignatorType"/>
+   <xsd:element name="AddressLocatorName" type="AddressLocatorNameType"/>
+   <xsd:element name="AddressPostCode" type="AddressPostCodeType"/>
+   <xsd:element name="AddressPostName" type="AddressPostNameType"/>
+   <xsd:element name="AddressPostOfficeBox" type="AddressPostOfficeBoxType"/>
+   <xsd:element name="AddressThoroughfare" type="AddressThoroughfareType"/>
+   <xsd:element name="ChannelID" type="ChannelIDType"/>
+   <xsd:element name="GeometryCoordinateReferenceSystemID"
+                type="GeometryCoordinateReferenceSystemIDType"/>
+   <xsd:element name="GeometryCoordinates" type="GeometryCoordinatesType"/>
+   <xsd:element name="GeometryTypeCode" type="GeometryTypeCodeType"/>
+   <xsd:element name="InputDescription" type="InputDescriptionType"/>
+   <xsd:element name="InputName" type="InputNameType"/>
+   <xsd:element name="InputTypeCode" type="InputTypeCodeType"/>
+   <xsd:element name="JurisdictionID" type="JurisdictionIDType"/>
+   <xsd:element name="JurisdictionName" type="JurisdictionNameType"/>
+   <xsd:element name="LegalEntityAlternativeName" type="LegalEntityAlternativeNameType"/>
+   <xsd:element name="LegalEntityCompanyActivityCode"
+                type="LegalEntityCompanyActivityCodeType"/>
+   <xsd:element name="LegalEntityCompanyStatusCode"
+                type="LegalEntityCompanyStatusCodeType"/>
+   <xsd:element name="LegalEntityCompanyTypeCode" type="LegalEntityCompanyTypeCodeType"/>
+   <xsd:element name="LegalEntityID" type="LegalEntityIDType"/>
+   <xsd:element name="LegalEntityLegalID" type="LegalEntityLegalIDType"/>
+   <xsd:element name="LegalEntityLegalName" type="LegalEntityLegalNameType"/>
+   <xsd:element name="LocationGeographicID" type="LocationGeographicIDType"/>
+   <xsd:element name="LocationGeographicName" type="LocationGeographicNameType"/>
+   <xsd:element name="OutputDescription" type="OutputDescriptionType"/>
+   <xsd:element name="OutputName" type="OutputNameType"/>
+   <xsd:element name="OutputTypeCode" type="OutputTypeCodeType"/>
+   <xsd:element name="PeriodOfTimeEndDate" type="PeriodOfTimeEndDateType"/>
+   <xsd:element name="PeriodOfTimeStartDate" type="PeriodOfTimeStartDateType"/>
+   <xsd:element name="PersonAlternativeName" type="PersonAlternativeNameType"/>
+   <xsd:element name="PersonBirthDate" type="PersonBirthDateType"/>
+   <xsd:element name="PersonBirthName" type="PersonBirthNameType"/>
+   <xsd:element name="PersonDeathDate" type="PersonDeathDateType"/>
+   <xsd:element name="PersonFamilyName" type="PersonFamilyNameType"/>
+   <xsd:element name="PersonFullName" type="PersonFullNameType"/>
+   <xsd:element name="PersonGenderCode" type="PersonGenderCodeType"/>
+   <xsd:element name="PersonGivenName" type="PersonGivenNameType"/>
+   <xsd:element name="PersonID" type="PersonIDType"/>
+   <xsd:element name="PersonPatronymicName" type="PersonPatronymicNameType"/>
+   <xsd:element name="PublicServiceDescription" type="PublicServiceDescriptionType"/>
+   <xsd:element name="PublicServiceHomepageID" type="PublicServiceHomepageIDType"/>
+   <xsd:element name="PublicServiceLanguageCode" type="PublicServiceLanguageCodeType"/>
+   <xsd:element name="PublicServiceName" type="PublicServiceNameType"/>
+   <xsd:element name="PublicServiceTypeCode" type="PublicServiceTypeCodeType"/>
+   <xsd:element name="RuleID" type="RuleIDType"/>
+   <!-- ===== Type Definitions ===== -->
+   <!-- ===== Basic Business Information Entity Type Definitions ===== -->
+   <xsd:complexType name="AddressAddressAreaType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AddressAdminUnitLocationOneType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AddressAdminUnitLocationTwoType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AddressFullAddressType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AddressIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AddressLocatorDesignatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AddressLocatorNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AddressPostCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AddressPostNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AddressPostOfficeBoxType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AddressThoroughfareType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChannelIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GeometryCoordinateReferenceSystemIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GeometryCoordinatesType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GeometryTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InputDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InputNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InputTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="JurisdictionIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="JurisdictionNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LegalEntityAlternativeNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LegalEntityCompanyActivityCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LegalEntityCompanyStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LegalEntityCompanyTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LegalEntityIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LegalEntityLegalIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LegalEntityLegalNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LocationGeographicIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LocationGeographicNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OutputDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OutputNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OutputTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PeriodOfTimeEndDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PeriodOfTimeStartDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PersonAlternativeNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PersonBirthDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PersonBirthNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PersonDeathDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PersonFamilyNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PersonFullNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PersonGenderCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PersonGivenNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PersonIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PersonPatronymicNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PublicServiceDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PublicServiceHomepageIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PublicServiceLanguageCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PublicServiceNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PublicServiceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RuleIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== --><!--
+  Copyright (c) European Union, 2014
+  Licensed under the ISA Open Metadata Licence
+
+  ISA Open Metadata Licence v1.1
+
+  1. Copyright
+
+  The Work (as defined below) is provided under the terms of this ISA 
+  Open Metadata Licence (this Licence, or later versions of this Licence 
+  published by the European Commission). The work is protected by 
+  copyright and/or other applicable law. Any use of the work other than 
+  as authorised under this Licence or copyright law is prohibited.
+
+  By exercising any rights to the work provided here, you accept and
+  agree to be bound by the terms of this Licence. The Owner (as defined
+  below) grants You the rights contained here in consideration of your
+  acceptance of such terms and conditions.
+
+  2. Definitions
+
+  The “Owner” is the European Union represented by the European 
+  Commission, which is the original licensor and/or controls the 
+  copyright and any other intellectual and industrial property rights 
+  related to the Work.
+
+  The “Work” is the information and/or data offered to You under this 
+  Licence, according to the “Copyright Notice”:
+
+      Copyright (c) European Union, YEAR
+      Licensed under the ISA Open Metadata Licence,
+      Original author: CONTRIBUTOR(s)
+
+  "You" means the natural or legal person, or body of persons corporate 
+  or incorporate, acquiring rights under this licence.
+
+  "Contributor" means the natural or legal person whose Work is, by 
+  agreement with the European Commission, provided under this Licence.
+
+  "Use" means doing any act which is restricted by copyright or database 
+  right, whether in the original medium or in any other medium, and 
+  includes without limitation distributing, copying, adapting, modifying 
+  as may be technically necessary to use it in a different mode or 
+  format. It includes "re-Use", meaning the use, communication to the 
+  public and/or distribution of the Works for purposes other than the 
+  initial purpose for which the Work was produced.
+
+  3. Rights
+
+  In accordance to Commission Decision 2011/833/EU, You are herewith 
+  granted a worldwide, royalty-free, perpetual, non-exclusive licence to 
+  Use and re-Use the Works and any modifications thereof for any 
+  commercial and non-commercial purpose allowed by the law and provided 
+  that the following conditions are met:
+    a) Distributions or communication to the public must retain the 
+       above Copyright Notice;
+    b) Distributions must retain the following “No Warranty” disclaimer;
+    c) Where possible and practical, distributions or communication to 
+       the public will provide a link to the Joinup platform;
+    d) Acts directed to mislead others or misrepresent the Work, its 
+       content or source are prohibited;
+    e) You will not use the name of the European Commission and that of 
+       its Contributor(s) to endorse or promote products and services 
+       derived from the Use of the Work without specific prior written 
+       permission.
+
+  4. No Warranty
+
+  EACH WORK IS PROVIDED "AS IS" WITHOUT REPRESENTATIONS, WARRANTIES, 
+  OBLIGATIONS AND LIABILITIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, TO 
+  THE FULL EXTENT PERMITTED BY LAW INCLUDING, BUT NOT LIMITED TO, ANY 
+  IMPLIED WARRANTY OF MERCHANTABILITY, INTEGRATION, SATISFACTORY QUALITY 
+  AND FITNESS FOR A PARTICULAR PURPOSE.
+
+  EXCEPT IN THE CASES OF WILFUL MISCONDUCT OR DAMAGES DIRECTLY CAUSED TO 
+  NATURAL PERSONS, NEITHER EUROPEAN UNION NOR ITS CONTRIBUTOR(S) WILL BE 
+  LIABLE FOR ANY INCIDENTAL, CONSEQUENTIAL, DIRECT OR INDIRECT DAMAGES 
+  INCLUDING BUT NOT LIMITED TO THE LOSS OF DATA, LOST PROFITS, OR ANY 
+  OTHER FINANCIAL LOSS ARISING FROM THE USE OF, OR INABILITY TO USE, 
+  EVEN IF THE EUROPEAN UNION HAS BEEN NOTIFIED OF THE POSSIBILITY OF 
+  SUCH LOSS, DAMAGES, CLAIMS OR COSTS OR FOR ANY CLAIM BY ANY THIRD 
+  PARTY. HOWEVER, THE LICENSOR WILL BE LIABLE UNDER STATUTORY PRODUCT 
+  LIABILITY LAWS AS FAR SUCH LAWS APPLY TO THE WORK.
+
+  5. Governing Law
+
+  This licence is governed by the laws of the jurisdiction in which the 
+  first Contributor listed in the Copyright Notice has its principal 
+  place of business, unless otherwise specified by this Contributor.
+-->

--- a/lib/schemas/eidas-saml-extensions.xsd
+++ b/lib/schemas/eidas-saml-extensions.xsd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+        xmlns="http://eidas.europa.eu/saml-extensions"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="http://eidas.europa.eu/saml-extensions"
+        elementFormDefault="qualified"
+        attributeFormDefault="unqualified"
+        xmlns:eidas="http://eidas.europa.eu/saml-extensions"
+        version="1">
+
+    <xsd:element name="SPType" type="SPTypeType"/>
+
+    <xsd:simpleType name="SPTypeType">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="public"/>
+            <xsd:enumeration value="private"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:element name="RequestedAttributes" type="eidas:RequestedAttributesType" />
+    <xsd:complexType name="RequestedAttributesType">
+        <xsd:sequence>
+            <xsd:element minOccurs="0" maxOccurs="unbounded" ref="eidas:RequestedAttribute"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="RequestedAttribute" type="eidas:RequestedAttributeType" />
+    <xsd:complexType name="RequestedAttributeType">
+        <xsd:sequence>
+            <xsd:element minOccurs="0" maxOccurs="unbounded" ref="eidas:AttributeValue"/>
+        </xsd:sequence>
+        <xsd:attribute name="Name" use="required" type="xsd:string"/>
+        <xsd:attribute name="NameFormat" use="required" type="xsd:anyURI"/>
+        <xsd:attribute name="FriendlyName" use="optional" type="xsd:string"/>
+        <xsd:attribute name="isRequired" use="optional" type="xsd:boolean"/>
+        <xsd:anyAttribute namespace="##other" processContents="lax"/>
+    </xsd:complexType>
+    <xsd:element name="AttributeValue" type="xsd:anyType" />
+
+</xsd:schema>

--- a/lib/schemas/eidas_schema.xsd
+++ b/lib/schemas/eidas_schema.xsd
@@ -1,0 +1,243 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+        xmlns="http://eidas.europa.eu/attributes/naturalperson"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="http://eidas.europa.eu/attributes/naturalperson"
+        elementFormDefault="qualified"
+        attributeFormDefault="unqualified"
+        version="1">
+
+    <xsd:attribute name="LatinScript" type="xsd:boolean" default="true"/>
+
+    <!--
+        Mandatory attribute types for a natural person.
+    -->
+    <xsd:simpleType name="PersonIdentifierType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Unique identifier for the natural person as defined by the eIDAS Regulation.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:complexType name="CurrentFamilyNameType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Current family name of the natural person.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute ref="LatinScript"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="CurrentGivenNameType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Current given names of the natural person.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute ref="LatinScript"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:simpleType name="DateOfBirthType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Date of Birth for the Natural Person (Based on xsd:date i.e. YYYY-MM-DD format).
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:date"/>
+    </xsd:simpleType>
+
+    <!--
+        Optional attribute types for a natural person.
+    -->
+    <xsd:complexType name="CurrentAddressStructuredType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Current address of the natural person.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="PoBox" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="LocatorDesignator" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="LocatorName" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="CvaddressArea" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="Thoroughfare" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="PostName" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="AdminunitFirstline" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="AdminunitSecondline" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="PostCode" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:simpleType name="CurrentAddressType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Current address of the natural person as a base64 encoded string.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="GenderType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Gender of the natural person.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Male"/>
+            <xsd:enumeration value="Female"/>
+            <xsd:enumeration value="Unspecified"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:complexType name="BirthNameType">
+        <xsd:annotation>
+            <xsd:documentation>
+                First name(s) and family name(s) of the natural person at birth.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute ref="LatinScript"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="PlaceOfBirthType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Place of birth for a natural person.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+
+
+
+    <!--
+            Mandatory attribute types for a legal person.
+        -->
+    <xsd:simpleType name="LegalPersonIdentifierType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Unique identifier for the legal person as defined by the eIDAS Regulation.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:complexType name="LegalNameType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Current legal name for the legal person or organisation.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute ref="LatinScript"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <!--
+        Optional attribute types for a legal person.
+    -->
+    <xsd:complexType name="LegalPersonAddressStructuredType">
+        <xsd:annotation>
+            <xsd:documentation>
+                The address the legal person has registered with the MS authority or operating address if not registered. For a company this should be the registered address within the MS issuing the eID.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="PoBox" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="LocatorDesignator" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="LocatorName" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="CvaddressArea" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="Thoroughfare" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="PostName" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="AdminunitFirstline" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="AdminunitSecondline" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="PostCode" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:simpleType name="LegalPersonAddressType">
+        <xsd:annotation>
+            <xsd:documentation>
+                The address the legal person has registered with the MS authority or operating address if not registered. For a company this should be the registered address within the MS issuing the eID as a base64 encoded string.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="VATRegistrationNumberType">
+        <xsd:annotation>
+            <xsd:documentation>VAT - VAT registration number
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="TaxReferenceType">
+        <xsd:annotation>
+            <xsd:documentation>TAX-Ref - tax reference number
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="D-2012-17-EUIdentifierType">
+        <xsd:annotation>
+            <xsd:documentation>D-2012/17/EU - the identifier used under Directive 2012/17/EU
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="LEIType">
+        <xsd:annotation>
+            <xsd:documentation>LEI - Legal Entity Identifier
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="EORIType">
+        <xsd:annotation>
+            <xsd:documentation>EORI - Economic Operator Registration and Identification
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="SEEDType">
+        <xsd:annotation>
+            <xsd:documentation>SEED - System for Exchange of Excise Data
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="SICType">
+        <xsd:annotation>
+            <xsd:documentation>SIC - Standard Industrial Classification
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+</xsd:schema>

--- a/lib/schemas/microsoft_cgg_2016.xsd
+++ b/lib/schemas/microsoft_cgg_2016.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+        xmlns="http://schemas.microsoft.com/cgg/2016/identity/claims/approvedclaim"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="http://schemas.microsoft.com/cgg/2016/identity/claims/approvedclaim"
+        elementFormDefault="qualified"
+        attributeFormDefault="unqualified"
+        version="1">
+
+    <xsd:simpleType name="string">
+        <xsd:annotation>
+            <xsd:documentation>
+                Unique identifier for the natural person as defined by the eIDAS Regulation.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+</xsd:schema>

--- a/lib/schemas/saml-schema-protocol-2.0.xsd
+++ b/lib/schemas/saml-schema-protocol-2.0.xsd
@@ -13,6 +13,8 @@
         schemaLocation="saml-schema-assertion-2.0.xsd"/>
     <import namespace="http://www.w3.org/2000/09/xmldsig#"
         schemaLocation="xmldsig-core-schema.xsd"/>
+    <import namespace="http://eidas.europa.eu/saml-extensions"
+	schemaLocation="eidas-saml-extensions.xsd"/>
     <annotation>
         <documentation>
             Document identifier: saml-schema-protocol-2.0

--- a/lib/schemas/saml_eidas_extension.xsd
+++ b/lib/schemas/saml_eidas_extension.xsd
@@ -8,9 +8,6 @@
         xmlns:eidas="http://eidas.europa.eu/saml-extensions"
         version="1">
 
-    <xsd:import namespace="http://eidas.europa.eu/attributes/naturalperson" schemaLocation="saml_eidas_natural_person.xsd"/>
-    <xsd:import namespace="http://schemas.microsoft.com/cgg/2016/identity/claims/approvedclaim" schemaLocation="microsoft_cgg_2016.xsd"/>
-
     <xsd:element name="SPType" type="SPTypeType"/>
 
     <xsd:simpleType name="SPTypeType">

--- a/lib/schemas/saml_eidas_legal_person.xsd
+++ b/lib/schemas/saml_eidas_legal_person.xsd
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+        xmlns="http://eidas.europa.eu/attributes/legalperson"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="http://eidas.europa.eu/attributes/legalperson"
+        elementFormDefault="qualified"
+        attributeFormDefault="unqualified"
+        version="1">
+
+    <xsd:attribute name="LatinScript" type="xsd:boolean" default="true"/>
+
+    <!--
+        Mandatory attribute types for a legal person.
+    -->
+    <xsd:simpleType name="LegalPersonIdentifierType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Unique identifier for the legal person as defined by the eIDAS Regulation.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:complexType name="LegalNameType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Current legal name for the legal person or organisation.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute ref="LatinScript"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <!--
+        Optional attribute types for a legal person.
+    -->
+    <xsd:complexType name="LegalPersonAddressStructuredType">
+        <xsd:annotation>
+            <xsd:documentation>
+                The address the legal person has registered with the MS authority or operating address if not registered. For a company this should be the registered address within the MS issuing the eID.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="PoBox" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="LocatorDesignator" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="LocatorName" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="CvaddressArea" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="Thoroughfare" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="PostName" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="AdminunitFirstline" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="AdminunitSecondline" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="PostCode" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:simpleType name="LegalPersonAddressType">
+        <xsd:annotation>
+            <xsd:documentation>
+                The address the legal person has registered with the MS authority or operating address if not registered. For a company this should be the registered address within the MS issuing the eID as a base64 encoded string.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="VATRegistrationNumberType">
+        <xsd:annotation>
+            <xsd:documentation>VAT - VAT registration number
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="TaxReferenceType">
+        <xsd:annotation>
+            <xsd:documentation>TAX-Ref - tax reference number
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="D-2012-17-EUIdentifierType">
+        <xsd:annotation>
+            <xsd:documentation>D-2012/17/EU - the identifier used under Directive 2012/17/EU
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="LEIType">
+        <xsd:annotation>
+            <xsd:documentation>LEI - Legal Entity Identifier
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="EORIType">
+        <xsd:annotation>
+            <xsd:documentation>EORI - Economic Operator Registration and Identification
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="SEEDType">
+        <xsd:annotation>
+            <xsd:documentation>SEED - System for Exchange of Excise Data
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="SICType">
+        <xsd:annotation>
+            <xsd:documentation>SIC - Standard Industrial Classification
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+</xsd:schema>

--- a/lib/schemas/saml_eidas_natural_person.xsd
+++ b/lib/schemas/saml_eidas_natural_person.xsd
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+        xmlns="http://eidas.europa.eu/attributes/naturalperson"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="http://eidas.europa.eu/attributes/naturalperson"
+        elementFormDefault="qualified"
+        attributeFormDefault="unqualified"
+        version="1">
+
+    <xsd:attribute name="LatinScript" type="xsd:boolean" default="true"/>
+
+    <!--
+        Mandatory attribute types for a natural person.
+    -->
+    <xsd:simpleType name="PersonIdentifierType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Unique identifier for the natural person as defined by the eIDAS Regulation.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:complexType name="CurrentFamilyNameType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Current family name of the natural person.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute ref="LatinScript"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="CurrentGivenNameType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Current given names of the natural person.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute ref="LatinScript"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:simpleType name="DateOfBirthType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Date of Birth for the Natural Person (Based on xsd:date i.e. YYYY-MM-DD format).
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:date"/>
+    </xsd:simpleType>
+
+    <!--
+        Optional attribute types for a natural person.
+    -->
+    <xsd:complexType name="CurrentAddressStructuredType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Current address of the natural person.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="PoBox" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="LocatorDesignator" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="LocatorName" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="CvaddressArea" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="Thoroughfare" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="PostName" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="AdminunitFirstline" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="AdminunitSecondline" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="PostCode" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:simpleType name="CurrentAddressType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Current address of the natural person as a base64 encoded string.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="GenderType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Gender of the natural person.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Male"/>
+            <xsd:enumeration value="Female"/>
+            <xsd:enumeration value="Unspecified"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:complexType name="BirthNameType">
+        <xsd:annotation>
+            <xsd:documentation>
+                First name(s) and family name(s) of the natural person at birth.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute ref="LatinScript"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="PlaceOfBirthType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Place of birth for a natural person.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+
+</xsd:schema>

--- a/lib/schemas/stork-schema-assertion-1.0.xsd
+++ b/lib/schemas/stork-schema-assertion-1.0.xsd
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+  elementFormDefault="qualified" 
+  targetNamespace="urn:eu:stork:names:tc:STORK:1.0:assertion" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns:storkp="urn:eu:stork:names:tc:STORK:1.0:protocol"
+  xmlns:stork="urn:eu:stork:names:tc:STORK:1.0:assertion">
+
+  <xs:element name="QualityAuthenticationAssuranceLevel" type="stork:QualityAuthenticationAssuranceLevelType" />
+  <xs:element name="spSector" type="stork:SPSectorType" />
+  <xs:element name="spApplication" type="stork:SPApplicationType"/>
+  <xs:element name="spCountry" type="stork:CountryCodeType"/>
+  <xs:element name="CitizenCountryCode" type="stork:CountryCodeType" />
+  <xs:element name="RequestedAttribute" type="stork:RequestedAttributeType" />
+  <xs:element name="AttributeValue" type="xs:anyType" />
+  <xs:element name="canonicalResidenceAddress" type="stork:canonicalResidenceAddressType"/>
+  <xs:element name="countryCodeAddress" type="xs:anyType"/>
+  
+  <xs:attribute name="AttributeStatus" type="stork:AttributeStatusType" />
+
+
+  <xs:simpleType name="SPSectorType">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1" />
+      <xs:maxLength value="20" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="SPApplicationType">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1" />
+      <xs:maxLength value="100" />
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="AttributeStatusType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Available" />
+      <xs:enumeration value="NotAvailable" />
+      <xs:enumeration value="Withheld" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="QualityAuthenticationAssuranceLevelType">
+    <xs:restriction base="xs:integer">
+      <xs:minInclusive value="1" />
+      <xs:maxInclusive value="4" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="canonicalResidenceAddressType">
+    <xs:all>
+      <xs:element name="countryCodeAddress" type="xs:anyType"/>
+      <xs:element name="state" type="xs:string" minOccurs="0"/>            		
+      <xs:element name="municipalityCode" type="xs:string" minOccurs="0"/>
+      <xs:element name="town" type="xs:string"/>
+      <xs:element name="postalCode" type="xs:string"/>
+      <xs:element name="streetName" type="xs:string"/>
+      <xs:element name="streetNumber" type="xs:string" minOccurs="0"/>
+      <xs:element name="apartmentNumber" type="xs:string" minOccurs="0"/>
+    </xs:all>
+  </xs:complexType>
+  
+  <xs:simpleType name="CountryCodeType">
+    <xs:restriction base="xs:token">
+      <xs:pattern value="[A-Z]{2}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:complexType name="RequestedAttributeType">
+    <xs:sequence>
+      <xs:element minOccurs="0" maxOccurs="unbounded" ref="stork:AttributeValue"/>
+    </xs:sequence>
+    <xs:attribute name="Name" use="required" type="xs:string"/>
+    <xs:attribute name="NameFormat" use="required" type="xs:anyURI"/>
+    <xs:attribute name="FriendlyName" use="optional" type="xs:string"/>
+    <xs:attribute name="isRequired" use="optional" type="xs:boolean"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+</xs:schema>

--- a/lib/schemas/stork-schema-protocol-1.0.xsd
+++ b/lib/schemas/stork-schema-protocol-1.0.xsd
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+  elementFormDefault="qualified" 
+  targetNamespace="urn:eu:stork:names:tc:STORK:1.0:protocol" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"  
+  xmlns:storkp="urn:eu:stork:names:tc:STORK:1.0:protocol" 
+  xmlns:stork="urn:eu:stork:names:tc:STORK:1.0:assertion"
+  xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+
+  <xs:import namespace="urn:eu:stork:names:tc:STORK:1.0:assertion" schemaLocation="stork-schema-assertion-1.0.xsd"/>
+  <!--  <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd" /> -->
+  <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema.xsd" />
+  
+
+  <xs:element name="eIDSectorShare" type="xs:boolean" default="false"/>
+  <xs:element name="eIDCrossSectorShare" type="xs:boolean" default="false"/>
+  <xs:element name="eIDCrossBorderShare" type="xs:boolean" default="false"/>
+  <xs:element name="RequestedAttributes" type="storkp:RequestedAttributesType" />  
+  <xs:element name="AuthenticationAttributes" type="storkp:AuthenticationAttributesType" />
+  
+  <xs:complexType name="RequestedAttributesType">
+    <xs:sequence>
+      <xs:element minOccurs="0" maxOccurs="unbounded" ref="stork:RequestedAttribute"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="AuthenticationAttributesType">
+    <xs:sequence>
+      <xs:element name="VIDPAuthenticationAttributes" type="storkp:VIDPAuthenticationAttributesType" minOccurs="0" maxOccurs="1" />
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="VIDPAuthenticationAttributesType">
+    <xs:sequence>
+      <xs:element name="CitizenCountryCode" minOccurs="0" maxOccurs="1" type="stork:CountryCodeType" />
+      <xs:element name="SPInformation" minOccurs="1" maxOccurs="1" type="storkp:SPInformationType"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="SPInformationType">
+    <xs:sequence>
+      <xs:element name="SPID" minOccurs="1" maxOccurs="1" type="storkp:SPIDType" />
+      <xs:element name="SPCertSig" minOccurs="0" maxOccurs="1" type="storkp:SPCertSigType" />
+      <xs:element name="SPCertEnc" minOccurs="0" maxOccurs="1" type="storkp:SPCertEncType" />
+      <xs:element name="SPAuthRequest" minOccurs="0" maxOccurs="1" type="storkp:SPAuthRequestType"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:simpleType name="SPIDType">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1" />
+      <xs:maxLength value="20" />
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:complexType name="SPCertSigType">
+    <xs:sequence>
+      <xs:element minOccurs="1" ref="ds:KeyInfo" />
+    </xs:sequence>    
+  </xs:complexType>
+
+  <xs:complexType name="SPCertEncType">
+    <xs:sequence>
+      <xs:element minOccurs="1" ref="ds:KeyInfo" />
+    </xs:sequence>    
+  </xs:complexType>
+  
+  <xs:complexType name="SPAuthRequestType">
+    <xs:sequence>
+        <xs:any namespace="##other" processContents="lax" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType> 
+</xs:schema>

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -15,10 +15,10 @@ class RequestTest < Minitest::Test
     it "create the deflated SAMLRequest URL parameter" do
       auth_url = OneLogin::RubySaml::Authrequest.new.create(settings)
       assert_match /^http:\/\/example\.com\?SAMLRequest=/, auth_url
-      payload  = CGI.unescape(auth_url.split("=").last)
-      decoded  = Base64.decode64(payload)
+      payload = CGI.unescape(auth_url.split("=").last)
+      decoded = Base64.decode64(payload)
 
-      zstream  = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+      zstream = Zlib::Inflate.new(-Zlib::MAX_WBITS)
       inflated = zstream.inflate(decoded)
       zstream.finish
       zstream.close
@@ -28,10 +28,10 @@ class RequestTest < Minitest::Test
 
     it "create the deflated SAMLRequest URL parameter including the Destination" do
       auth_url = OneLogin::RubySaml::Authrequest.new.create(settings)
-      payload  = CGI.unescape(auth_url.split("=").last)
-      decoded  = Base64.decode64(payload)
+      payload = CGI.unescape(auth_url.split("=").last)
+      decoded = Base64.decode64(payload)
 
-      zstream  = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+      zstream = Zlib::Inflate.new(-Zlib::MAX_WBITS)
       inflated = zstream.inflate(decoded)
       zstream.finish
       zstream.close
@@ -43,8 +43,8 @@ class RequestTest < Minitest::Test
       settings.compress_request = false
       auth_url = OneLogin::RubySaml::Authrequest.new.create(settings)
       assert_match /^http:\/\/example\.com\?SAMLRequest=/, auth_url
-      payload  = CGI.unescape(auth_url.split("=").last)
-      decoded  = Base64.decode64(payload)
+      payload = CGI.unescape(auth_url.split("=").last)
+      decoded = Base64.decode64(payload)
 
       assert_match /^<samlp:AuthnRequest/, decoded
     end
@@ -53,10 +53,10 @@ class RequestTest < Minitest::Test
       settings.passive = true
       auth_url = OneLogin::RubySaml::Authrequest.new.create(settings)
       assert_match /^http:\/\/example\.com\?SAMLRequest=/, auth_url
-      payload  = CGI.unescape(auth_url.split("=").last)
-      decoded  = Base64.decode64(payload)
+      payload = CGI.unescape(auth_url.split("=").last)
+      decoded = Base64.decode64(payload)
 
-      zstream  = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+      zstream = Zlib::Inflate.new(-Zlib::MAX_WBITS)
       inflated = zstream.inflate(decoded)
       zstream.finish
       zstream.close
@@ -68,10 +68,10 @@ class RequestTest < Minitest::Test
       settings.protocol_binding = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'
       auth_url = OneLogin::RubySaml::Authrequest.new.create(settings)
       assert_match /^http:\/\/example\.com\?SAMLRequest=/, auth_url
-      payload  = CGI.unescape(auth_url.split("=").last)
-      decoded  = Base64.decode64(payload)
+      payload = CGI.unescape(auth_url.split("=").last)
+      decoded = Base64.decode64(payload)
 
-      zstream  = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+      zstream = Zlib::Inflate.new(-Zlib::MAX_WBITS)
       inflated = zstream.inflate(decoded)
       zstream.finish
       zstream.close
@@ -83,10 +83,10 @@ class RequestTest < Minitest::Test
       settings.attributes_index = 30
       auth_url = OneLogin::RubySaml::Authrequest.new.create(settings)
       assert_match /^http:\/\/example\.com\?SAMLRequest=/, auth_url
-      payload  = CGI.unescape(auth_url.split("=").last)
-      decoded  = Base64.decode64(payload)
+      payload = CGI.unescape(auth_url.split("=").last)
+      decoded = Base64.decode64(payload)
 
-      zstream  = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+      zstream = Zlib::Inflate.new(-Zlib::MAX_WBITS)
       inflated = zstream.inflate(decoded)
       zstream.finish
       zstream.close
@@ -97,10 +97,10 @@ class RequestTest < Minitest::Test
       settings.force_authn = true
       auth_url = OneLogin::RubySaml::Authrequest.new.create(settings)
       assert_match /^http:\/\/example\.com\?SAMLRequest=/, auth_url
-      payload  = CGI.unescape(auth_url.split("=").last)
-      decoded  = Base64.decode64(payload)
+      payload = CGI.unescape(auth_url.split("=").last)
+      decoded = Base64.decode64(payload)
 
-      zstream  = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+      zstream = Zlib::Inflate.new(-Zlib::MAX_WBITS)
       inflated = zstream.inflate(decoded)
       zstream.finish
       zstream.close
@@ -140,24 +140,24 @@ class RequestTest < Minitest::Test
     end
 
     it "accept extra parameters" do
-      auth_url = OneLogin::RubySaml::Authrequest.new.create(settings, { :hello => "there" })
+      auth_url = OneLogin::RubySaml::Authrequest.new.create(settings, {:hello => "there"})
       assert_match /&hello=there$/, auth_url
 
-      auth_url = OneLogin::RubySaml::Authrequest.new.create(settings, { :hello => nil })
+      auth_url = OneLogin::RubySaml::Authrequest.new.create(settings, {:hello => nil})
       assert_match /&hello=$/, auth_url
     end
 
     it "RelayState cases" do
-      auth_url = OneLogin::RubySaml::Authrequest.new.create(settings, { :RelayState => nil })
+      auth_url = OneLogin::RubySaml::Authrequest.new.create(settings, {:RelayState => nil})
       assert !auth_url.include?('RelayState')
 
-      auth_url = OneLogin::RubySaml::Authrequest.new.create(settings, { :RelayState => "http://example.com" })
+      auth_url = OneLogin::RubySaml::Authrequest.new.create(settings, {:RelayState => "http://example.com"})
       assert auth_url.include?('&RelayState=http%3A%2F%2Fexample.com')
 
-      auth_url = OneLogin::RubySaml::Authrequest.new.create(settings, { 'RelayState' => nil })
+      auth_url = OneLogin::RubySaml::Authrequest.new.create(settings, {'RelayState' => nil})
       assert !auth_url.include?('RelayState')
 
-      auth_url = OneLogin::RubySaml::Authrequest.new.create(settings, { 'RelayState' => "http://example.com" })
+      auth_url = OneLogin::RubySaml::Authrequest.new.create(settings, {'RelayState' => "http://example.com"})
       assert auth_url.include?('&RelayState=http%3A%2F%2Fexample.com')
     end
 
@@ -331,11 +331,22 @@ class RequestTest < Minitest::Test
       assert auth_doc.to_s =~ /<saml:AuthnContextDeclRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport<\/saml:AuthnContextDeclRef>/
     end
 
-    it "create multiple saml:AuthnContextDeclRef elements correctly " do
+    it "create multiple saml:AuthnContextDeclRef elements correctly" do
       settings.authn_context_decl_ref = ['name/password/uri', 'example/decl/ref']
       auth_doc = OneLogin::RubySaml::Authrequest.new.create_authentication_xml_doc(settings)
       assert auth_doc.to_s =~ /<saml:AuthnContextDeclRef>name\/password\/uri<\/saml:AuthnContextDeclRef>/
       assert auth_doc.to_s =~ /<saml:AuthnContextDeclRef>example\/decl\/ref<\/saml:AuthnContextDeclRef>/
+    end
+
+    it "create samlp:Extensions correctly in AuthRequest" do
+      settings.extensions[:sptype] = 'public'
+      settings.extensions[:requested_attributes] = [
+        OneLogin::RubySaml::RequestedAttribute.new({:Name => "http://eidas.europa.eu/attributes/naturalperson/DateOfBirth"}, settings)
+      ]
+      auth_doc = OneLogin::RubySaml::Authrequest.new.create_authentication_xml_doc(settings)
+      assert auth_doc.to_s =~ /<samlp:Extensions/
+      assert auth_doc.to_s =~ /<eidas:SPType/
+      assert auth_doc.to_s =~ /<eidas:RequestedAttributes/
     end
   end
 end

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -338,15 +338,32 @@ class RequestTest < Minitest::Test
       assert auth_doc.to_s =~ /<saml:AuthnContextDeclRef>example\/decl\/ref<\/saml:AuthnContextDeclRef>/
     end
 
-    it "create samlp:Extensions correctly in AuthRequest" do
+    it 'create samlp:Extensions correctly in AuthRequest' do
       settings.extensions[:sptype] = 'public'
       settings.extensions[:requested_attributes] = [
-        OneLogin::RubySaml::RequestedAttribute.new({:Name => "http://eidas.europa.eu/attributes/naturalperson/DateOfBirth"}, settings)
+        OneLogin::RubySaml::RequestedAttribute.new({:Name => 'http://eidas.europa.eu/attributes/naturalperson/DateOfBirth'}, settings)
       ]
       auth_doc = OneLogin::RubySaml::Authrequest.new.create_authentication_xml_doc(settings)
       assert auth_doc.to_s =~ /<samlp:Extensions/
       assert auth_doc.to_s =~ /<eidas:SPType/
       assert auth_doc.to_s =~ /<eidas:RequestedAttributes/
     end
+
+    it 'no extensions in output if no extensions configuration is provided' do
+      auth_doc = OneLogin::RubySaml::Authrequest.new.create_authentication_xml_doc(settings)
+      assert_nil auth_doc.to_s =~ /<samlp:Extensions/
+      assert_nil auth_doc.to_s =~ /<eidas:SPType/
+      assert_nil auth_doc.to_s =~ /<eidas:RequestedAttributes/
+    end
+
+    it 'only sptype is provided if no requested_attributes configuration' do
+      settings.extensions[:sptype] = 'public'
+      auth_doc = OneLogin::RubySaml::Authrequest.new.create_authentication_xml_doc(settings)
+
+      assert auth_doc.to_s =~ /<samlp:Extensions/
+      assert auth_doc.to_s =~ /<eidas:SPType/
+      assert_nil auth_doc.to_s =~ /<eidas:RequestedAttributes/
+    end
+
   end
 end

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -22,7 +22,8 @@ class SettingsTest < Minitest::Test
         :security, :certificate, :private_key,
         :authn_context, :authn_context_comparison, :authn_context_decl_ref,
         :assertion_consumer_logout_service_url,
-        :assertion_consumer_logout_service_binding
+        :assertion_consumer_logout_service_binding,
+        :extensions
       ]
 
       accessors.each do |accessor|


### PR DESCRIPTION
I'm very new to Ruby programming, so I'm sorry for any default mistakes I could've made.

This proposal should provide ability of ruby-saml package to provide samlp:Extensions element as of eidas saml extensions xsd (included in PR) together with SPType (ServiceProviderType) indication and RequestedAttributes collection, directly in AuthRequest

This is based on EC eIDAS eID Profile specification (https://ec.europa.eu/cefdigital/wiki/display/CEFDIGITAL/eIDAS+eID+Profile), specifically [eIDAS Message Format v1.2.pdf](https://ec.europa.eu/cefdigital/wiki/download/attachments/82773108/eIDAS%20SAML%20Message%20Format%20v.1.2%20Final.pdf?version=3&modificationDate=1571068651727&api=v2) sections 2.3.2 and 4.1

To explain changes:
- .gitignore - local vendor bundle should be ignored imo in ruby projects
- formatting of code (proper indentation of lines and missing whitespaces) in authrequest.rb, settings.rb and request_test.rb ( i haven't found any coding style guidelines with the project, so i've applied default lint recommendations from RuboCop in my RubyMine IDE)
- requested_attribute.rb - helper class to work with RequestedAttribute element, and provided that to REXML::Element.add_element
- new param of Settings.initialize, to allow combination of keeping none/one-of/both security and extensions attributes
- one test to validate, that code adds expected elements properly (this i plan to expand)
- one test to validate, that settings provide :extensions symbol accessor

While I'm sorry for including changes, not directly relevant to matters, it would be very painful for me to format all my code manually, so please excuse that