### PR TITLE
Check if response is encrypted

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ Remember to provide it to the Signature builder if you are sending a `GET RelayS
 signature validation process will fail at the Identity Provider.
 
 The Service Provider will sign the request/responses with its private key.
-The Identity Provider will validate the sign of the received request/responses with the public x500 cert of the
+The Identity Provider will validate the sign of the received request/responses with the public x509 cert of the
 Service Provider.
 
 Notice that this toolkit uses 'settings.certificate' and 'settings.private_key' for the sign and decrypt processes.

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -341,6 +341,17 @@ module OneLogin
         return options[:allowed_clock_drift].to_f
       end
 
+      # Checks if the SAML Response contains or not an EncryptedAssertion element
+      # @return [Boolean] True if the SAML Response contains an EncryptedAssertion element
+      #
+      def assertion_encrypted?
+        ! REXML::XPath.first(
+          document,
+          "(/p:Response/EncryptedAssertion/)|(/p:Response/a:EncryptedAssertion/)",
+          { "p" => PROTOCOL, "a" => ASSERTION }
+        ).nil?
+      end
+
       private
 
       # Validates the SAML Response (calls several validation methods)
@@ -965,17 +976,6 @@ module OneLogin
         response_node.add(decrypt_assertion(encrypted_assertion_node))
         encrypted_assertion_node.remove
         XMLSecurity::SignedDocument.new(response_node.to_s)
-      end
-
-      # Checks if the SAML Response contains or not an EncryptedAssertion element
-      # @return [Boolean] True if the SAML Response contains an EncryptedAssertion element
-      #
-      def assertion_encrypted?
-        ! REXML::XPath.first(
-          document,
-          "(/p:Response/EncryptedAssertion/)|(/p:Response/a:EncryptedAssertion/)",
-          { "p" => PROTOCOL, "a" => ASSERTION }
-        ).nil?
       end
 
       # Decrypts an EncryptedAssertion element


### PR DESCRIPTION
https://github.com/onelogin/ruby-saml/issues/532

+ Move `Response` class private method `assertion_encrypted?` to public
+ Fix minor typo in readme

