### PR TITLE
Improve clarity of Attributes#all's return type.

### DIFF
--- a/lib/onelogin/ruby-saml/attributes.rb
+++ b/lib/onelogin/ruby-saml/attributes.rb
@@ -79,7 +79,7 @@ module OneLogin
         self.class.single_value_compatibility ? single(canonize_name(name)) : multi(canonize_name(name))
       end
 
-      # @return [Array] Return all attributes as an array
+      # @return [Hash] Return all attributes as a hash
       #
       def all
         attributes


### PR DESCRIPTION
Despite the comments stating that `Attributes#all` returns an Array, and it actually returns a `Hash`.

```ruby
irb> att = OneLogin::RubySaml::Attributes.new({ 'name' => ['a', 'b'] })
=> #<OneLogin::RubySaml::Attributes:0x00005589de0fbd70 @attributes={"name"=>["a", "b"]}>
irb> att.all
=> {"name"=>["a", "b"]}
```


I've updated the comment accordingly.