### PR TITLE
Fetch attribute value

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,9 @@ Imagine this `saml:AttributeStatement`
       <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
       <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="1"/>
     </saml:Attribute>
+    <saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname">
+      <saml:AttributeValue>usersName</saml:AttributeValue>
+    </saml:Attribute>
   </saml:AttributeStatement>
 ```
 
@@ -474,7 +477,8 @@ pp(response.attributes)   # is an OneLogin::RubySaml::Attributes object
    "another_value"=>["value1", "value2"],
    "role"=>["role1", "role2", "role3"],
    "attribute_with_nil_value"=>[nil],
-   "attribute_with_nils_and_empty_strings"=>["", "valuePresent", nil, nil]}>
+   "attribute_with_nils_and_empty_strings"=>["", "valuePresent", nil, nil]
+   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"=>["usersName"]}>
 
 # Active single_value_compatibility
 OneLogin::RubySaml::Attributes.single_value_compatibility = true
@@ -491,6 +495,9 @@ pp(response.attributes.single(:role))
 pp(response.attributes.multi(:role))
 # => ["role1", "role2", "role3"]
 
+pp(response.attributes.fetch(:role))
+# => "role1"
+
 pp(response.attributes[:attribute_with_nil_value])
 # => nil
 
@@ -505,6 +512,9 @@ pp(response.attributes.single(:not_exists))
 
 pp(response.attributes.multi(:not_exists))
 # => nil
+
+pp(response.attributes.fetch(/givenname/))
+# => "usersName"
 
 # Deactive single_value_compatibility
 OneLogin::RubySaml::Attributes.single_value_compatibility = false
@@ -521,6 +531,9 @@ pp(response.attributes.single(:role))
 pp(response.attributes.multi(:role))
 # => ["role1", "role2", "role3"]
 
+pp(response.attributes.fetch(:role))
+# => ["role1", "role2", "role3"]
+
 pp(response.attributes[:attribute_with_nil_value])
 # => [nil]
 
@@ -535,6 +548,9 @@ pp(response.attributes.single(:not_exists))
 
 pp(response.attributes.multi(:not_exists))
 # => nil
+
+pp(response.attributes.fetch(/givenname/))
+# => ["usersName"]
 ```
 
 The `saml:AuthnContextClassRef` of the AuthNRequest can be provided by `settings.authn_context`; possible values are described at [SAMLAuthnCxt]. The comparison method can be set using `settings.authn_context_comparison` parameter. Possible values include: 'exact', 'better', 'maximum' and 'minimum' (default value is 'exact').

--- a/lib/onelogin/ruby-saml/attributes.rb
+++ b/lib/onelogin/ruby-saml/attributes.rb
@@ -113,6 +113,25 @@ module OneLogin
         end
       end
 
+      # Fetch attribute value using name or regex
+      # @param name [String|Regexp] The attribute name
+      # @return [String|Array] Depending on the single value compatibility status this returns:
+      #                        - First value if single_value_compatibility = true
+      #                          response.attributes['mail']  # => 'user@example.com'
+      #                        - All values if single_value_compatibility = false
+      #                          response.attributes['mail']  # => ['user@example.com','user@example.net']
+      #
+      def fetch(name)
+        attributes.each_key do |attribute_key|
+          if name.is_a?(Regexp)
+            return self[attribute_key] if name.match?(attribute_key)
+          elsif canonize_name(name) == canonize_name(attribute_key)
+            return self[attribute_key]
+          end
+        end
+        nil
+      end
+
       protected
 
       # stringifies all names so both 'email' and :email return the same result

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -1,0 +1,28 @@
+require File.expand_path(File.join(File.dirname(__FILE__), 'test_helper'))
+
+require 'onelogin/ruby-saml/attributes'
+
+class AttributesTest < Minitest::Test
+  describe 'Attributes' do
+    let(:attributes) do
+      OneLogin::RubySaml::Attributes.new({
+        'email' => ['tom@hanks.com'],
+        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname' => ['Tom'],
+        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname' => ['Hanks']
+      })
+    end
+
+    it 'fetches string attribute' do
+      assert_equal('tom@hanks.com', attributes.fetch('email'))
+    end
+
+    it 'fetches symbol attribute' do
+      assert_equal('tom@hanks.com', attributes.fetch(:email))
+    end
+
+    it 'fetches regexp attribute' do
+      assert_equal('Tom', attributes.fetch(/givenname/))
+      assert_equal('Hanks', attributes.fetch(/surname/))
+    end
+  end
+end


### PR DESCRIPTION
After setting up an AD-FS SSO and trying to pass a users first and last name through attributes, I found that AD-FS passes the following attribute names which are annoying/ugly to match:
```Ruby
# Attributes
{
  'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname' => ['Jarrad'],
  'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname' => ['M'],
}
saml_response.attributes['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname']
# Jarrad
```

I _thought_ a `#fetch` might be ideal here to handle cases where one might want to retrieve an attribute value using regular expression?
```Ruby
# Attributes
{
  'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname' => ['Jarrad'],
  'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname' => ['M'],
}
saml_response.attributes.fetch(/givenname/)
# Jarrad
saml_response.attributes.fetch(/surname/)
# M
```

Happy to hear your thoughts ✌️ 