### PR TITLE
Expose which service binding was chosen for single sign on service

### DIFF
--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -210,6 +210,7 @@ module OneLogin
             :idp_entity_id => @entity_id,
             :name_identifier_format => idp_name_id_format,
             :idp_sso_target_url => single_signon_service_url(options),
+            :single_signon_service_binding => single_signon_service_binding(options[:sso_binding]),
             :idp_slo_target_url => single_logout_service_url(options),
             :idp_attribute_names => attribute_names,
             :idp_cert => nil,

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -32,6 +32,7 @@ module OneLogin
       # IdP Data
       attr_accessor :idp_entity_id
       attr_accessor :idp_sso_target_url
+      attr_accessor :single_signon_service_binding
       attr_accessor :idp_slo_target_url
       attr_accessor :idp_cert
       attr_accessor :idp_cert_fingerprint

--- a/test/idp_metadata_parser_test.rb
+++ b/test/idp_metadata_parser_test.rb
@@ -25,6 +25,7 @@ class IdpMetadataParserTest < Minitest::Test
 
       assert_equal "https://hello.example.com/access/saml/idp.xml", settings.idp_entity_id
       assert_equal "https://hello.example.com/access/saml/login", settings.idp_sso_target_url
+      assert_equal "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect", settings.single_signon_service_binding
       assert_equal "F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72", settings.idp_cert_fingerprint
       assert_equal "https://hello.example.com/access/saml/logout", settings.idp_slo_target_url
       assert_equal "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified", settings.name_identifier_format


### PR DESCRIPTION
# What
Expose which service binding was chosen for `idp_sso_target_url`

# Why
Knowing the chosen binding helps application code to choose:
1) `redirect_to` when the chosen binding is `HTTP-Redirect`
2) `render :post_with_js` when the chosen binding is `HTTP-POST`