### PR TITLE
Update Getting Started example

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Using `Gemfile`
 
 ```ruby
 # latest stable
-gem 'ruby-saml', '~> 1.9.0'
+gem 'ruby-saml', '~> 1.11.0'
 
 # or track master for bleeding-edge
 gem 'ruby-saml', :github => 'onelogin/ruby-saml'


### PR DESCRIPTION
Updates the gem version from **1.9.0** to **1.11.0** in the example of the _Getting Started_ section.