### PR TITLE
More specific error messages for request certificate validation

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -863,7 +863,7 @@ module OneLogin
           valid = false
           expired = false
           idp_certs[:signing].each do |idp_cert|
-            valid = doc.validate_document_with_cert(idp_cert)
+            valid = doc.validate_document_with_cert(idp_cert, @soft)
             if valid
               if settings.security[:check_idp_cert_expiration]
                 if OneLogin::RubySaml::Utils.is_cert_expired(idp_cert)

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -863,8 +863,12 @@ module OneLogin
           valid = false
           expired = false
           idp_certs[:signing].each do |idp_cert|
-            valid = doc.validate_document_with_cert(idp_cert, @soft)
+            valid = doc.validate_document_with_cert(idp_cert, true)
             if valid
+              # required to reset errors as there could be issues with previous certificates
+              doc.reset_errors!
+              reset_errors!
+
               if settings.security[:check_idp_cert_expiration]
                 if OneLogin::RubySaml::Utils.is_cert_expired(idp_cert)
                   expired = true

--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -260,7 +260,7 @@ module XMLSecurity
 
         # check saml response cert matches provided idp cert
         if idp_cert.to_pem != cert.to_pem
-          return false
+          return append_error("SAML response certificate does not match idp certificate", soft)
         end
       else
         base64_cert = Base64.encode64(idp_cert.to_pem)

--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -241,7 +241,7 @@ module XMLSecurity
       validate_signature(base64_cert, soft)
     end
 
-    def validate_document_with_cert(idp_cert)
+    def validate_document_with_cert(idp_cert, soft = true)
       # get cert from response
       cert_element = REXML::XPath.first(
         self,

--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -255,12 +255,12 @@ module XMLSecurity
         begin
           cert = OpenSSL::X509::Certificate.new(cert_text)
         rescue OpenSSL::X509::CertificateError => _e
-          return append_error("Certificate Error", soft)
+          return append_error("Document certificate error", soft)
         end
 
         # check saml response cert matches provided idp cert
         if idp_cert.to_pem != cert.to_pem
-          return append_error("SAML response certificate does not match idp certificate", soft)
+          return append_error("Document certificate does not match idp certificate", soft)
         end
       else
         base64_cert = Base64.encode64(idp_cert.to_pem)

--- a/test/xml_security_test.rb
+++ b/test/xml_security_test.rb
@@ -418,6 +418,17 @@ class XmlSecurityTest < Minitest::Test
               assert_equal(["Certificate Error"], document.errors)
             end
           end
+
+          describe 'when response cert is different from idp cert' do
+            let(:idp_cert) { OpenSSL::X509::Certificate.new(ruby_saml_cert_text2) }
+
+            it 'is not valid' do
+              exception = assert_raises(OneLogin::RubySaml::ValidationError) do
+                document.validate_document_with_cert(idp_cert, false)
+              end
+              assert_equal("SAML response certificate does not match idp certificate", exception.message)
+            end
+          end
         end
 
         describe 'when response has no cert but you have local cert' do

--- a/test/xml_security_test.rb
+++ b/test/xml_security_test.rb
@@ -405,8 +405,21 @@ class XmlSecurityTest < Minitest::Test
           it 'is valid' do
             assert document.validate_document_with_cert(idp_cert), 'Document should be valid'
           end
+
+          describe 'when response cert is invalid' do
+            let(:document_data) do
+              contents = read_response('response_with_signed_message_and_assertion.xml')
+              contents.sub(/<ds:X509Certificate>.*<\/ds:X509Certificate>/,
+                           "<ds:X509Certificate>an-invalid-certificate</ds:X509Certificate>")
+            end
+
+            it 'is not valid' do
+              assert !document.validate_document_with_cert(idp_cert), 'Document should be valid'
+              assert_equal(["Certificate Error"], document.errors)
+            end
+          end
         end
-        
+
         describe 'when response has no cert but you have local cert' do
           let(:document) { OneLogin::RubySaml::Response.new(response_document_valid_signed_without_x509certificate).document }
           let(:idp_cert) { OpenSSL::X509::Certificate.new(ruby_saml_cert_text) }

--- a/test/xml_security_test.rb
+++ b/test/xml_security_test.rb
@@ -415,7 +415,7 @@ class XmlSecurityTest < Minitest::Test
 
             it 'is not valid' do
               assert !document.validate_document_with_cert(idp_cert), 'Document should be valid'
-              assert_equal(["Certificate Error"], document.errors)
+              assert_equal(["Document certificate error"], document.errors)
             end
           end
 
@@ -426,7 +426,7 @@ class XmlSecurityTest < Minitest::Test
               exception = assert_raises(OneLogin::RubySaml::ValidationError) do
                 document.validate_document_with_cert(idp_cert, false)
               end
-              assert_equal("SAML response certificate does not match idp certificate", exception.message)
+              assert_equal("Document certificate does not match idp certificate", exception.message)
             end
           end
         end

--- a/test/xml_security_test.rb
+++ b/test/xml_security_test.rb
@@ -395,49 +395,51 @@ class XmlSecurityTest < Minitest::Test
     end
 
     describe '#validate_document_with_cert' do
+      let(:document_data) { read_response('response_with_signed_message_and_assertion.xml') }
+      let(:document) { OneLogin::RubySaml::Response.new(document_data).document }
+      let(:idp_cert) { OpenSSL::X509::Certificate.new(ruby_saml_cert_text) }
+      let(:fingerprint) { '4b68c453c7d994aad9025c99d5efcf566287fe8d' }
+
       describe 'with valid document ' do
-        describe 'when response has cert' do
-          let(:document_data) { read_response('response_with_signed_message_and_assertion.xml') }
-          let(:document) { OneLogin::RubySaml::Response.new(document_data).document }
-          let(:idp_cert) { OpenSSL::X509::Certificate.new(ruby_saml_cert_text) }
-          let(:fingerprint) { '4b68c453c7d994aad9025c99d5efcf566287fe8d' }
+        it 'is valid' do
+          assert document.validate_document_with_cert(idp_cert), 'Document should be valid'
+        end
+      end
 
-          it 'is valid' do
-            assert document.validate_document_with_cert(idp_cert), 'Document should be valid'
-          end
+      describe 'when response has no cert but you have local cert' do
+        let(:document_data) { response_document_valid_signed_without_x509certificate }
 
-          describe 'when response cert is invalid' do
-            let(:document_data) do
-              contents = read_response('response_with_signed_message_and_assertion.xml')
-              contents.sub(/<ds:X509Certificate>.*<\/ds:X509Certificate>/,
-                           "<ds:X509Certificate>an-invalid-certificate</ds:X509Certificate>")
-            end
+        it 'is valid' do
+          assert document.validate_document_with_cert(idp_cert), 'Document should be valid'
+        end
+      end
 
-            it 'is not valid' do
-              assert !document.validate_document_with_cert(idp_cert), 'Document should be valid'
-              assert_equal(["Document certificate error"], document.errors)
-            end
-          end
-
-          describe 'when response cert is different from idp cert' do
-            let(:idp_cert) { OpenSSL::X509::Certificate.new(ruby_saml_cert_text2) }
-
-            it 'is not valid' do
-              exception = assert_raises(OneLogin::RubySaml::ValidationError) do
-                document.validate_document_with_cert(idp_cert, false)
-              end
-              assert_equal("Document certificate does not match idp certificate", exception.message)
-            end
-          end
+      describe 'when response cert is invalid' do
+        let(:document_data) do
+          contents = read_response('response_with_signed_message_and_assertion.xml')
+          contents.sub(/<ds:X509Certificate>.*<\/ds:X509Certificate>/,
+                       "<ds:X509Certificate>an-invalid-certificate</ds:X509Certificate>")
         end
 
-        describe 'when response has no cert but you have local cert' do
-          let(:document) { OneLogin::RubySaml::Response.new(response_document_valid_signed_without_x509certificate).document }
-          let(:idp_cert) { OpenSSL::X509::Certificate.new(ruby_saml_cert_text) }
+        it 'is not valid' do
+          assert !document.validate_document_with_cert(idp_cert), 'Document should be valid'
+          assert_equal(["Document certificate error"], document.errors)
+        end
+      end
 
-          it 'is valid' do
-            assert document.validate_document_with_cert(idp_cert), 'Document should be valid'
+      describe 'when response cert is different from idp cert' do
+        let(:idp_cert) { OpenSSL::X509::Certificate.new(ruby_saml_cert_text2) }
+
+        it 'is not valid' do
+          exception = assert_raises(OneLogin::RubySaml::ValidationError) do
+            document.validate_document_with_cert(idp_cert, false)
           end
+          assert_equal("Document certificate does not match idp certificate", exception.message)
+        end
+
+        it 'is not valid (soft = true)' do
+          document.validate_document_with_cert(idp_cert)
+          assert_equal(["Document certificate does not match idp certificate"], document.errors)
         end
       end
     end


### PR DESCRIPTION
When validations find that the SAML request certificate does not match idp certificate they report the generic error message "Response signature validation failed";
This PR adds a more specific message for this scenario.

additionally the 'soff' variable which is required when calling the "append_error" method was not passed down to the 'validate_document_with_cert' method. This is also fixed

