### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
     "README.md"
   ]
   s.files = `git ls-files`.split("\n")
-  s.homepage = %q{http://github.com/onelogin/ruby-saml}
+  s.homepage = %q{https://github.com/onelogin/ruby-saml}
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.7}


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/ruby-saml or some tools or APIs that use the gem's metadata.