### PR TITLE
Add :skip_audience option

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], {skip_authnst
 response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], {skip_conditions: true}) # skips conditions
 response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], {skip_subject_confirmation: true}) # skips subject confirmation
 response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], {skip_recipient_check: true}) # doens't skip subject confirmation, but skips the recipient check which is a sub check of the subject_confirmation check
+response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], {skip_audience: true}) # skips audience check
 ```
 
 All that's left is to wrap everything in a controller and reference it in the initialization and consumption URLs in OneLogin. A full controller example could look like this:

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -34,7 +34,7 @@ module OneLogin
       # This is not a whitelist to allow people extending OneLogin::RubySaml:Response
       # and pass custom options
       AVAILABLE_OPTIONS = [
-        :allowed_clock_drift, :check_duplicated_attributes, :matches_request_id, :settings, :skip_authnstatement, :skip_conditions,
+        :allowed_clock_drift, :check_duplicated_attributes, :matches_request_id, :settings, :skip_audience, :skip_authnstatement, :skip_conditions,
         :skip_destination, :skip_recipient_check, :skip_subject_confirmation
       ]
       # TODO: Update the comment on initialize to describe every option
@@ -47,6 +47,8 @@ module OneLogin
       #                          or :matches_request_id that will validate that the response matches the ID of the request,
       #                          or skip the subject confirmation validation with the :skip_subject_confirmation option
       #                          or skip the recipient validation of the subject confirmation element with :skip_recipient_check option
+      #                          or skip the audience validation with :skip_audience option
+      #
       def initialize(response, options = {})
         raise ArgumentError.new("Response cannot be nil") if response.nil?
 
@@ -595,12 +597,14 @@ module OneLogin
       end
 
       # Validates the Audience, (If the Audience match the Service Provider EntityID)
+      # If the response was initialized with the :skip_audience option, this validation is skipped,
       # If fails, the error is added to the errors array
       # @return [Boolean] True if there is an Audience Element that match the Service Provider EntityID, otherwise False if soft=True
       # @raise [ValidationError] if soft == false and validation fails
       #
       def validate_audience
         return true if audiences.empty? || settings.sp_entity_id.nil? || settings.sp_entity_id.empty?
+        return true if options[:skip_audience]
 
         unless audiences.include? settings.sp_entity_id
           s = audiences.count > 1 ? 's' : '';

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -603,8 +603,8 @@ module OneLogin
       # @raise [ValidationError] if soft == false and validation fails
       #
       def validate_audience
-        return true if audiences.empty? || settings.sp_entity_id.nil? || settings.sp_entity_id.empty?
         return true if options[:skip_audience]
+        return true if audiences.empty? || settings.sp_entity_id.nil? || settings.sp_entity_id.empty?
 
         unless audiences.include? settings.sp_entity_id
           s = audiences.count > 1 ? 's' : '';

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -38,6 +38,7 @@ class RubySamlTest < Minitest::Test
     let(:response_multiple_signed) { OneLogin::RubySaml::Response.new(read_invalid_response("multiple_signed.xml.base64")) }
     let(:response_audience_self_closed) { OneLogin::RubySaml::Response.new(read_response("response_audience_self_closed_tag.xml.base64")) }
     let(:response_invalid_audience) { OneLogin::RubySaml::Response.new(read_invalid_response("invalid_audience.xml.base64")) }
+    let(:response_invalid_audience_with_skip) { OneLogin::RubySaml::Response.new(read_invalid_response("invalid_audience.xml.base64"), {:skip_audience => true}) }
     let(:response_invalid_signed_element) { OneLogin::RubySaml::Response.new(read_invalid_response("response_invalid_signed_element.xml.base64")) }
     let(:response_invalid_issuer_assertion) { OneLogin::RubySaml::Response.new(read_invalid_response("invalid_issuer_assertion.xml.base64")) }
     let(:response_invalid_issuer_message) { OneLogin::RubySaml::Response.new(read_invalid_response("invalid_issuer_message.xml.base64")) }
@@ -682,6 +683,13 @@ class RubySamlTest < Minitest::Test
         response_invalid_audience.settings.sp_entity_id = "https://invalid.example.com/audience"
         assert !response_invalid_audience.send(:validate_audience)
         assert_includes response_invalid_audience.errors, generate_audience_error(response_invalid_audience.settings.sp_entity_id, ['http://invalid.audience.com'])
+      end
+
+      it "return true when there is no valid audience but skip_destination option is used" do
+        response_invalid_audience_with_skip.settings = settings
+        response_invalid_audience_with_skip.settings.sp_entity_id = "https://invalid.example.com/audience"
+        assert response_invalid_audience_with_skip.send(:validate_audience)
+        assert_empty response_invalid_audience_with_skip.errors
       end
     end
 


### PR DESCRIPTION
# Summary

Adds an option to the SAML Response class, to skip the assertions during `#validate_audience`. 

## Why this matters?

Some Service providers want to relax validation, and have this control via configuration. This was first surfaced in #515 and @pitbulk requested opening a PR to introduce it. Here's the PR =)