### PR TITLE
add basic auth for descriptor url

### DIFF
--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -189,6 +189,7 @@ module OneLogin
         end
 
         get = Net::HTTP::Get.new(uri.request_uri)
+        get.basic_auth uri.user, uri.password if uri.user
         @response = http.request(get)
         return response.body if response.is_a? Net::HTTPSuccess
 


### PR DESCRIPTION
Currently it is not possible to supply an url to any of the "parse" methods of `OneLogin::RubySaml::IdpMetadataParser` that contain a username and password portion in front ("Basic Auth")

This pull request adds the support. Feel free to merge it or close the pull request, if this is not desired.

(Use case: staging environments where the IDP is behind basic auth)