### PR TITLE
Define 'soft' variable to prevent exception when doc cert is invalid

### DIFF
--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -241,7 +241,7 @@ module XMLSecurity
       validate_signature(base64_cert, soft)
     end
 
-    def validate_document_with_cert(idp_cert)
+    def validate_document_with_cert(idp_cert, soft = true)
       # get cert from response
       cert_element = REXML::XPath.first(
         self,

--- a/test/xml_security_test.rb
+++ b/test/xml_security_test.rb
@@ -395,6 +395,19 @@ class XmlSecurityTest < Minitest::Test
     end
 
     describe '#validate_document_with_cert' do
+      describe 'with invalid document ' do
+        describe 'when certificate is invalid' do
+          let(:document_data) { read_response('response_with_signed_message_and_assertion.xml')
+            .sub(/<ds:X509Certificate>.*<\/ds:X509Certificate>/, "<ds:X509Certificate>invalid<\/ds:X509Certificate>") }
+          let(:document) { OneLogin::RubySaml::Response.new(document_data).document }
+          let(:idp_cert) { OpenSSL::X509::Certificate.new(ruby_saml_cert_text) }
+
+          it 'is invalid' do
+            refute document.validate_document_with_cert(idp_cert), 'Document should be invalid'
+          end
+        end
+      end
+
       describe 'with valid document ' do
         describe 'when response has cert' do
           let(:document_data) { read_response('response_with_signed_message_and_assertion.xml') }


### PR DESCRIPTION
The line `return append_error("Certificate Error", soft)` inside `#validate_document_with_cert` can cause a NameError as `soft` is not defined.

This causes the NameError to propagate upwards in the case that the `ds:X509Certificate` element contains an invalid certificate.

This can be triggered in the real world when you have an invalid `ds:X509Certificate` element on your response and are using the `idp_cert_multi` configuration to validate it against multiple certificates.

Fix and test verifying fix included.