### PR TITLE
Not raise an error when there are multiple signature nodes

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -835,13 +835,8 @@ module OneLogin
           )
         end
 
-        if sig_elements.size != 1
-          if  sig_elements.size == 0
-             append_error("Signed element id ##{doc.signed_element_id} is not found")
-          else
-             append_error("Signed element id ##{doc.signed_element_id} is found more than once")
-          end
-          return append_error(error_msg)
+        if  sig_elements.size == 0
+          append_error("Signed element id ##{doc.signed_element_id} is not found")
         end
 
 


### PR DESCRIPTION
Thanks for providing this wonderful library. I found one problem while using this library. This wasn't compliant with the SAML 2.0 spec so I fixed it. Please confirm.

## Expected
Allow the presence of multiple signatures.

SAML 2.0 spec allows for this. 
In fact, the Java library `java-saml` you provide allows multiple signatures.

See: https://github.com/onelogin/java-saml/blob/e69b53b1befbd3065d958d325d44fbc9bc74a56d/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java#L308-L310

## Now
not allow the presence of multiple signatures.

commit by https://github.com/perryism/ruby-saml/commit/059abe4cfde3e4afbc703d6eadba7831fd6ea343
