### PR TITLE
add runtime dependency rexml

### DIFF
--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |s|
   else
     s.add_runtime_dependency('nokogiri', '>= 1.10.5')
   end
+  s.add_runtime_dependency('rexml')
 
   s.add_development_dependency('coveralls')
   s.add_development_dependency('minitest', '~> 5.5')


### PR DESCRIPTION
rexml are rexml are default gems to bundled gem for ruby 2.8 (3.0)
https://bugs.ruby-lang.org/issues/16485
