### PR TITLE
Fix error in 1.12 that breaks SloLogoutresponse and LogoutRequest

### DIFF
--- a/lib/onelogin/ruby-saml/logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/logoutrequest.rb
@@ -32,14 +32,14 @@ module OneLogin
       #
       def create(settings, params={})
         params = create_params(settings, params)
-        params_prefix = (settings.idp_slo_target_url =~ /\?/) ? '&' : '?'
+        params_prefix = (settings.idp_slo_service_url =~ /\?/) ? '&' : '?'
         saml_request = CGI.escape(params.delete("SAMLRequest"))
         request_params = "#{params_prefix}SAMLRequest=#{saml_request}"
         params.each_pair do |key, value|
           request_params << "&#{key.to_s}=#{CGI.escape(value.to_s)}"
         end
-        raise SettingError.new "Invalid settings, idp_slo_target_url is not set!" if settings.idp_slo_target_url.nil? or settings.idp_slo_target_url.empty?
-        @logout_url = settings.idp_slo_target_url + request_params
+        raise SettingError.new "Invalid settings, idp_slo_service_url is not set!" if settings.idp_slo_service_url.nil? or settings.idp_slo_service_url.empty?
+        @logout_url = settings.idp_slo_service_url + request_params
       end
 
       # Creates the Get parameters for the logout request.
@@ -109,7 +109,7 @@ module OneLogin
         root.attributes['ID'] = uuid
         root.attributes['IssueInstant'] = time
         root.attributes['Version'] = "2.0"
-        root.attributes['Destination'] = settings.idp_slo_target_url  unless settings.idp_slo_target_url.nil? or settings.idp_slo_target_url.empty?
+        root.attributes['Destination'] = settings.idp_slo_service_url  unless settings.idp_slo_service_url.nil? or settings.idp_slo_service_url.empty?
 
         if settings.sp_entity_id
           issuer = root.add_element "saml:Issuer"

--- a/lib/onelogin/ruby-saml/slo_logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutresponse.rb
@@ -36,15 +36,15 @@ module OneLogin
       #
       def create(settings, request_id = nil, logout_message = nil, params = {}, logout_status_code = nil)
         params = create_params(settings, request_id, logout_message, params, logout_status_code)
-        params_prefix = (settings.idp_slo_target_url =~ /\?/) ? '&' : '?'
-        url = settings.idp_slo_response_service_url || settings.idp_slo_target_url
+        params_prefix = (settings.idp_slo_service_url =~ /\?/) ? '&' : '?'
+        url = settings.idp_slo_response_service_url || settings.idp_slo_service_url
         saml_response = CGI.escape(params.delete("SAMLResponse"))
         response_params = "#{params_prefix}SAMLResponse=#{saml_response}"
         params.each_pair do |key, value|
           response_params << "&#{key.to_s}=#{CGI.escape(value.to_s)}"
         end
 
-        raise SettingError.new "Invalid settings, idp_slo_target_url is not set!" if url.nil? or url.empty?
+        raise SettingError.new "Invalid settings, idp_slo_service_url is not set!" if url.nil? or url.empty?
         @logout_url = url + response_params
       end
 
@@ -117,7 +117,8 @@ module OneLogin
         response_doc = XMLSecurity::Document.new
         response_doc.uuid = uuid
 
-        destination = settings.idp_slo_response_service_url || settings.idp_slo_target_url
+        destination = settings.idp_slo_response_service_url || settings.idp_slo_service_url
+
 
         root = response_doc.add_element 'samlp:LogoutResponse', { 'xmlns:samlp' => 'urn:oasis:names:tc:SAML:2.0:protocol', "xmlns:saml" => "urn:oasis:names:tc:SAML:2.0:assertion" }
         root.attributes['ID'] = uuid

--- a/test/logoutrequest_test.rb
+++ b/test/logoutrequest_test.rb
@@ -8,7 +8,7 @@ class RequestTest < Minitest::Test
     let(:settings) { OneLogin::RubySaml::Settings.new }
 
     before do
-      settings.idp_slo_target_url = "http://unauth.com/logout"
+      settings.idp_slo_service_url = "http://unauth.com/logout"
       settings.name_identifier_value = "f00f00"
     end
 
@@ -43,7 +43,7 @@ class RequestTest < Minitest::Test
     end
 
     it "set sessionindex" do
-      settings.idp_slo_target_url = "http://example.com"
+      settings.idp_slo_service_url = "http://example.com"
       sessionidx = OneLogin::RubySaml::Utils.uuid
       settings.sessionindex = sessionidx
 
@@ -75,7 +75,7 @@ class RequestTest < Minitest::Test
 
     describe "when the target url contains a query string" do
       it "create the SAMLRequest parameter correctly" do
-        settings.idp_slo_target_url = "http://example.com?field=value"
+        settings.idp_slo_service_url = "http://example.com?field=value"
 
         unauth_url = OneLogin::RubySaml::Logoutrequest.new.create(settings)
         assert_match /^http:\/\/example.com\?field=value&SAMLRequest/, unauth_url
@@ -84,7 +84,7 @@ class RequestTest < Minitest::Test
 
     describe "consumation of logout may need to track the transaction" do
       it "have access to the request uuid" do
-        settings.idp_slo_target_url = "http://example.com?field=value"
+        settings.idp_slo_service_url = "http://example.com?field=value"
 
         unauth_req = OneLogin::RubySaml::Logoutrequest.new
         unauth_url = unauth_req.create(settings)

--- a/test/logoutresponse_test.rb
+++ b/test/logoutresponse_test.rb
@@ -225,7 +225,7 @@ class RubySamlTest < Minitest::Test
 
         before do
           settings.soft = true
-          settings.idp_slo_target_url = "http://example.com?field=value"
+          settings.idp_slo_service_url = "http://example.com?field=value"
           settings.security[:logout_responses_signed] = true
           settings.security[:embed_sign] = false
           settings.certificate = ruby_saml_cert_text
@@ -373,7 +373,7 @@ class RubySamlTest < Minitest::Test
 
         before do
           settings.soft = true
-          settings.idp_slo_target_url = "http://example.com?field=value"
+          settings.idp_slo_service_url = "http://example.com?field=value"
           settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA1
           settings.security[:logout_responses_signed] = true
           settings.security[:embed_sign] = false

--- a/test/slo_logoutrequest_test.rb
+++ b/test/slo_logoutrequest_test.rb
@@ -54,7 +54,6 @@ class RubySamlTest < Minitest::Test
 
       it "collect errors when collect_errors=true" do
         settings.idp_entity_id = 'http://idp.example.com/invalid'
-        settings.idp_slo_target_url = "http://example.com?field=value"
         settings.security[:logout_requests_signed] = true
         settings.security[:embed_sign] = false
         settings.certificate = ruby_saml_cert_text
@@ -247,7 +246,6 @@ class RubySamlTest < Minitest::Test
 
     describe "#validate_signature" do
       before do
-        settings.idp_slo_target_url = "http://example.com?field=value"
         settings.security[:logout_requests_signed] = true
         settings.security[:embed_sign] = false
         settings.certificate = ruby_saml_cert_text
@@ -406,7 +404,6 @@ class RubySamlTest < Minitest::Test
 
     describe "#validate_signature with multiple idp certs" do
       before do
-        settings.idp_slo_target_url = "http://example.com?field=value"
         settings.certificate = ruby_saml_cert_text
         settings.private_key = ruby_saml_key_text
         settings.idp_cert = nil

--- a/test/slo_logoutresponse_test.rb
+++ b/test/slo_logoutresponse_test.rb
@@ -10,7 +10,7 @@ class SloLogoutresponseTest < Minitest::Test
 
     before do
       settings.idp_entity_id = 'https://app.onelogin.com/saml/metadata/SOMEACCOUNT'
-      settings.idp_slo_target_url = "http://unauth.com/logout"
+      settings.idp_slo_service_url = "http://unauth.com/logout"
       settings.name_identifier_value = "f00f00"
       settings.compress_request = true
       settings.certificate = ruby_saml_cert_text


### PR DESCRIPTION
In 1.12 idp_slo_target_url was deprecated in favour of idp_slo_service_url. However, the latter was still in use in SloLogoutresponse, which broke in the following way:

```ruby

idp_metadata = <<~XML
<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" ID="_d0886a22-c7b4-4dad-a631-62ce5ef18356" entityID="https://stubidp.sustainsys.com/Metadata" cacheDuration="PT15M" validUntil="2021-03-03T19:27:37Z">
  <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
    <SignedInfo>
      <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
      <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
      <Reference URI="#_d0886a22-c7b4-4dad-a631-62ce5ef18356">
        <Transforms>
          <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
          <Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
        </Transforms>
        <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
        <DigestValue>0tl3z7LGVtCEWh8DxF+YTgDQkHrYG49vs9iBzOXYqIg=</DigestValue>
      </Reference>
    </SignedInfo>
    <SignatureValue>gZ4v8Vm/BP+GVg0s0h+JE9LgCq+IJCDusDEI6vTjARghbGsrkww26225Q9brV55zwq9WUyembvxOd/7Z7YTvv7z1n51a0e2qi+UK9fsX2Pdl8pX/DSAVciQkdVWJ9BLYeDAuAusnm/b8l/39xD2tFdNvb9z8frtvf0ybpWmh9As=</SignatureValue>
    <KeyInfo>
      <X509Data>
        <X509Certificate>MIICFTCCAYKgAwIBAgIQzfcJCkM1YahDtRGYsLphrDAJBgUrDgMCHQUAMCExHzAdBgNVBAMTFnN0dWJpZHAuc3VzdGFpbnN5cy5jb20wHhcNMTcxMjE0MTE1NDUwWhcNMzkxMjMxMjM1OTU5WjAhMR8wHQYDVQQDExZzdHViaWRwLnN1c3RhaW5zeXMuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDSSq8EX46J1yprfaBdh4pWII+/E7ypHM1NjG7mCwFwbkjq2tpSBuoASrQftbjIKqjVzxtxETw802VJu5CJR4d3Zdy5jD8NRTesfaQDazX7iiqisfnxmIdDhtJS0lXeBlj4MipoUW6l8Qsjx7ltZSwdfFLyh+bMqIrwOhMWGs82vQIDAQABo1YwVDBSBgNVHQEESzBJgBCBBNba7KNF5wnXqmYcejn6oSMwITEfMB0GA1UEAxMWc3R1YmlkcC5zdXN0YWluc3lzLmNvbYIQzfcJCkM1YahDtRGYsLphrDAJBgUrDgMCHQUAA4GBAHonBGahlldp7kcN5HGGnvogT8a0nNpM7GMdKhtzpLO3Uk3HyT3AAIKWiSoEv2n1BTalJ/CY/+te/JZPVGhWVzoi5JYytpj5gM0O7RH0a3/yUE8S8YLV2h0a2gsdoMvTRTnTm9CnXezCKqhjYjwsmOZtiCIYuFqX71d/pg5uoJfs</X509Certificate>
      </X509Data>
    </KeyInfo>
  </Signature>
  <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
    <KeyDescriptor>
      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
        <X509Data>
          <X509Certificate>MIICFTCCAYKgAwIBAgIQzfcJCkM1YahDtRGYsLphrDAJBgUrDgMCHQUAMCExHzAdBgNVBAMTFnN0dWJpZHAuc3VzdGFpbnN5cy5jb20wHhcNMTcxMjE0MTE1NDUwWhcNMzkxMjMxMjM1OTU5WjAhMR8wHQYDVQQDExZzdHViaWRwLnN1c3RhaW5zeXMuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDSSq8EX46J1yprfaBdh4pWII+/E7ypHM1NjG7mCwFwbkjq2tpSBuoASrQftbjIKqjVzxtxETw802VJu5CJR4d3Zdy5jD8NRTesfaQDazX7iiqisfnxmIdDhtJS0lXeBlj4MipoUW6l8Qsjx7ltZSwdfFLyh+bMqIrwOhMWGs82vQIDAQABo1YwVDBSBgNVHQEESzBJgBCBBNba7KNF5wnXqmYcejn6oSMwITEfMB0GA1UEAxMWc3R1YmlkcC5zdXN0YWluc3lzLmNvbYIQzfcJCkM1YahDtRGYsLphrDAJBgUrDgMCHQUAA4GBAHonBGahlldp7kcN5HGGnvogT8a0nNpM7GMdKhtzpLO3Uk3HyT3AAIKWiSoEv2n1BTalJ/CY/+te/JZPVGhWVzoi5JYytpj5gM0O7RH0a3/yUE8S8YLV2h0a2gsdoMvTRTnTm9CnXezCKqhjYjwsmOZtiCIYuFqX71d/pg5uoJfs</X509Certificate>
        </X509Data>
      </KeyInfo>
    </KeyDescriptor>
    <ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://stubidp.sustainsys.com/ArtifactResolve" index="0" isDefault="true" />
    <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://stubidp.sustainsys.com/Logout" />
    <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://stubidp.sustainsys.com/Logout" />
    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://stubidp.sustainsys.com/" />
    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://stubidp.sustainsys.com/" />
  </IDPSSODescriptor>
</EntityDescriptor>
XML

idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
settings = idp_metadata_parser.parse(idp_metadata)

logout_response = OneLogin::RubySaml::SloLogoutresponse.new.create(settings)
```

it fails with this error:

`OneLogin::RubySaml::SettingError: Invalid settings, idp_slo_target_url is not set!`

I've addressed this in this PR, and done the same thing in the LogoutRequest class which has the same issue. Note: it might be worth removing the attr_accessor for `idp_slo_target_url` altogether from the Settings class? Because the reason that tests didn't catch this is that this attribute was/is still settable, even though it isn't in use as far as I understand.