### PR TITLE
Bugs/577 validate signature broken

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# docker build -t ruby-saml .
+# docker run -it --rm ruby-saml bundle exec rake
+ARG ruby_version=latest
+FROM ruby:${ruby_version}
+
+WORKDIR /src
+
+COPY Gemfile .
+COPY *gemspec .
+RUN mkdir -p lib/onelogin/ruby-saml
+COPY lib/onelogin/ruby-saml/version.rb lib/onelogin/ruby-saml/version.rb
+RUN bundle
+
+COPY . .

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -828,7 +828,7 @@ module OneLogin
         # otherwise, review if the decrypted assertion contains a signature
         sig_elements = REXML::XPath.match(
           document,
-          "/p:Response[@ID=$id]/ds:Signature]",
+          "/p:Response[@ID=$id]/ds:Signature",
           { "p" => PROTOCOL, "ds" => DSIG },
           { 'id' => document.signed_element_id }
         )


### PR DESCRIPTION
#577

With REXML 3.2.5 (security release from this morning) and ruby-saml 1.12.0, calling validate_signature leads to an exception:

REXML::ParseException: Garbage component exists at the end: <]>: </p:Response[@id=$id]/ds:Signature]>
/usr/local/rvm/gems/ruby-2.7.2/gems/rexml-3.2.5/lib/rexml/parsers/xpathparser.rb:28:in `parse'
/usr/local/rvm/gems/ruby-2.7.2/gems/rexml-3.2.5/lib/rexml/xpath_parser.rb:80:in `parse'
/usr/local/rvm/gems/ruby-2.7.2/gems/rexml-3.2.5/lib/rexml/xpath.rb:78:in `match'
/usr/local/rvm/gems/ruby-2.7.2/gems/ruby-saml-1.12.0/lib/onelogin/ruby-saml/response.rb:829:in `validate_signature'
It seems it doesn't like the ] at the end of the XPath that ruby-saml is trying to use. Is that character necessary?
