### PR TITLE
Do not append " | " to OneLogin::RubySaml::Response#status_code unnecessarily

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -227,11 +227,10 @@ module OneLogin
               statuses = nodes.collect do |inner_node|
                 inner_node.attributes["Value"]
               end
-              extra_code = statuses.join(" | ")
-              if extra_code
-                code = "#{code} | #{extra_code}"
-              end
+
+              code = [code, statuses].flatten.join(" | ")
             end
+
             code
           end
         end

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -1635,6 +1635,16 @@ class RubySamlTest < Minitest::Test
       end
 
     end
+
+    describe "#status_code" do
+      it 'urn:oasis:names:tc:SAML:2.0:status:Responder' do
+        assert_equal response_statuscode_responder.status_code, 'urn:oasis:names:tc:SAML:2.0:status:Responder'
+      end
+
+      it 'urn:oasis:names:tc:SAML:2.0:status:Requester and urn:oasis:names:tc:SAML:2.0:status:UnsupportedBinding' do
+        assert_equal response_double_statuscode.status_code, 'urn:oasis:names:tc:SAML:2.0:status:Requester | urn:oasis:names:tc:SAML:2.0:status:UnsupportedBinding'
+      end
+    end
     describe "test qualified name id in attributes" do
 
       it "parsed the nameid" do


### PR DESCRIPTION
It turns out that `OneLogin::RubySaml::Response#status_code` only work as expected when we have multiple status codes in the response. When it has only one status code it is appending  `" | "` unecessarily to the end.

Steps to reproduce can be found on https://github.com/onelogin/ruby-saml/issues/584.