### PR TITLE
Support milliseconds in cacheDuration parsing

### DIFF
--- a/lib/onelogin/ruby-saml/utils.rb
+++ b/lib/onelogin/ruby-saml/utils.rb
@@ -16,18 +16,18 @@ module OneLogin
       DSIG      = "http://www.w3.org/2000/09/xmldsig#"
       XENC      = "http://www.w3.org/2001/04/xmlenc#"
       DURATION_FORMAT = %r(^
-        (-?)P                         # 1: Duration sign
+        (-?)P                       # 1: Duration sign
         (?:
-          (?:(\d+)Y)?                 # 2: Years
-          (?:(\d+)M)?                 # 3: Months
-          (?:(\d+)D)?                 # 4: Days
+          (?:(\d+)Y)?               # 2: Years
+          (?:(\d+)M)?               # 3: Months
+          (?:(\d+)D)?               # 4: Days
           (?:T
-            (?:(\d+)H)?               # 5: Hours
-            (?:(\d+)M)?               # 6: Minutes
-            (?:(\d+)S)?   # 7: Seconds and optional milliseconds
+            (?:(\d+)H)?             # 5: Hours
+            (?:(\d+)M)?             # 6: Minutes
+            (?:(\d+(?:[.,]\d+)?)S)? # 7: Seconds
           )?
           |
-          (\d+)W                      # 8: Weeks
+          (\d+)W                    # 8: Weeks
         )
       $)x
 
@@ -59,13 +59,8 @@ module OneLogin
           raise Exception.new("Invalid ISO 8601 duration")
         end
 
-        durYears = matches[2].to_i
-        durMonths = matches[3].to_i
-        durDays = matches[4].to_i
-        durHours = matches[5].to_i
-        durMinutes = matches[6].to_i
-        durSeconds = matches[7].to_f
-        durWeeks = matches[8].to_i
+        durYears, durMonths, durDays, durHours, durMinutes, durSeconds, durWeeks =
+          matches[2..8].map { |match| match ? match.tr(',', '.').to_f : 0.0 }
 
         if matches[1] == "-"
           durYears = -durYears

--- a/lib/onelogin/ruby-saml/utils.rb
+++ b/lib/onelogin/ruby-saml/utils.rb
@@ -15,7 +15,21 @@ module OneLogin
 
       DSIG      = "http://www.w3.org/2000/09/xmldsig#"
       XENC      = "http://www.w3.org/2001/04/xmlenc#"
-      DURATION_FORMAT = %r(^(-?)P(?:(?:(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?)|(?:(\d+)W))$)
+      DURATION_FORMAT = %r(^
+        (-?)P                         # 1: Duration sign
+        (?:
+          (?:(\d+)Y)?                 # 2: Years
+          (?:(\d+)M)?                 # 3: Months
+          (?:(\d+)D)?                 # 4: Days
+          (?:T
+            (?:(\d+)H)?               # 5: Hours
+            (?:(\d+)M)?               # 6: Minutes
+            (?:(\d+)S)?   # 7: Seconds and optional milliseconds
+          )?
+          |
+          (\d+)W                      # 8: Weeks
+        )
+      $)x
 
       # Checks if the x509 cert provided is expired
       #
@@ -37,10 +51,10 @@ module OneLogin
       #                            current time.
       #
       # @return [Integer] The new timestamp, after the duration is applied.
-      # 
+      #
       def self.parse_duration(duration, timestamp=Time.now.utc)
         matches = duration.match(DURATION_FORMAT)
-      
+
         if matches.nil?
           raise Exception.new("Invalid ISO 8601 duration")
         end

--- a/lib/onelogin/ruby-saml/utils.rb
+++ b/lib/onelogin/ruby-saml/utils.rb
@@ -59,18 +59,10 @@ module OneLogin
           raise Exception.new("Invalid ISO 8601 duration")
         end
 
-        durYears, durMonths, durDays, durHours, durMinutes, durSeconds, durWeeks =
-          matches[2..8].map { |match| match ? match.tr(',', '.').to_f : 0.0 }
+        sign = matches[1] == '-' ? -1 : 1
 
-        if matches[1] == "-"
-          durYears = -durYears
-          durMonths = -durMonths
-          durDays = -durDays
-          durHours = -durHours
-          durMinutes = -durMinutes
-          durSeconds = -durSeconds
-          durWeeks = -durWeeks
-        end
+        durYears, durMonths, durDays, durHours, durMinutes, durSeconds, durWeeks =
+          matches[2..8].map { |match| match ? sign * match.tr(',', '.').to_f : 0.0 }
 
         initial_datetime = Time.at(timestamp).utc.to_datetime
         final_datetime = initial_datetime.next_year(durYears)

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -1,6 +1,41 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 
 class UtilsTest < Minitest::Test
+  describe ".parse_duration" do
+    DURATIONS_FROM_EPOCH = {
+      # Basic formats
+      "P1Y1M1D"        => "1971-02-02T00:00:00.000Z",
+      "PT1H1M1S"       => "1970-01-01T01:01:01.000Z",
+      "P1W"            => "1970-01-08T00:00:00.000Z",
+      "P1Y1M1DT1H1M1S" => "1971-02-02T01:01:01.000Z",
+
+      # Negative duration
+      "-P1Y1M1DT1H1M1S" => "1968-11-29T22:58:59.000Z",
+
+      # Nominal wraparounds
+      "P13M" => "1971-02-01T00:00:00.000Z",
+      "P31D" => "1970-02-01T00:00:00.000Z",
+    }
+
+    def result(duration, reference = 0)
+      Time.at(
+        OneLogin::RubySaml::Utils.parse_duration(duration, reference)
+      ).utc.iso8601(3)
+    end
+
+    DURATIONS_FROM_EPOCH.each do |duration, expected|
+      it "parses #{duration} to return #{expected} from the given timestamp" do
+        assert_equal expected, result(duration)
+      end
+    end
+
+    it "returns the last calendar day of the next month when advancing from a longer month to a shorter one" do
+      initial_timestamp = Time.iso8601("1970-01-31T00:00:00.000Z").to_i
+
+      assert_equal "1970-02-28T00:00:00.000Z", result("P1M", initial_timestamp)
+    end
+  end
+
   describe ".format_cert" do
     let(:formatted_certificate) {read_certificate("formatted_certificate")}
     let(:formatted_chained_certificate) {read_certificate("formatted_chained_certificate")}

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -15,6 +15,10 @@ class UtilsTest < Minitest::Test
       # Nominal wraparounds
       "P13M" => "1971-02-01T00:00:00.000Z",
       "P31D" => "1970-02-01T00:00:00.000Z",
+
+      # Decimal seconds
+      "PT0.5S" => "1970-01-01T00:00:00.500Z",
+      "PT0,5S" => "1970-01-01T00:00:00.500Z"
     }
 
     def result(duration, reference = 0)


### PR DESCRIPTION
Since the introduction of `cacheDuration` parsing in 25cbddd we've been seeing metadata parsing failures for one of our IdPs, whose `cacheDuration` value is set to `"PT6H0M0.000S"`

This seems like a valid ISO8601 duration, however the regexp being used for parsing doesn't allow for the possibility of milliseconds.

This PR adds an optional non-captured group to the regexp to permit them. Since the captured string value is already being converted using `.to_f`, this should work without further changes.

To achieve minimal test coverage I've added a seconds string to one of the existing metadata examples with a zero value; this reproduces the failure and confirms the fix without needing to add a specific test case.

### Feedback

I'm new to this project so absolutely any feedback would be welcome. In particular, is the approach taken to test coverage sufficient, or would you prefer to add an explicit test case? This seemed simpler since the duration parsing isn't directly tested, but I'm happy to introduce unit tests there if that's preferred.