### PR TITLE
Added Regex support for fractional seconds duration

### DIFF
--- a/lib/onelogin/ruby-saml/utils.rb
+++ b/lib/onelogin/ruby-saml/utils.rb
@@ -15,7 +15,7 @@ module OneLogin
 
       DSIG      = "http://www.w3.org/2000/09/xmldsig#"
       XENC      = "http://www.w3.org/2001/04/xmlenc#"
-      DURATION_FORMAT = %r(^(-?)P(?:(?:(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?)|(?:(\d+)W))$)
+      DURATION_FORMAT = %r(^(-?)P(?=\d|T\d)(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)([DW]))?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$)
 
       # Checks if the x509 cert provided is expired
       #

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -254,6 +254,12 @@ class UtilsTest < Minitest::Test
         assert_equal '', OneLogin::RubySaml::Utils.element_text(element)
       end
 
+      describe 'duration_parse' do
+        it 'matches duration with fractional seconds' do
+          duration = "P0Y0M30DT0H0M0.000S"
+          assert OneLogin::RubySaml::Utils.parse_duration(duration)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Had a customer send in XML that had a valid duration with fractional seconds  (0.000S) but the Regex parser did not support that. .  Updated Regex expression to support fractional seconds.    Backwards compatible to support integer seconds (0S)

## Related PRs
None


## Todos
- [X ] Tests

## Deploy Notes
None

## Steps to Test or Reproduce
Duration that failed with current code: "P0Y0M30DT0H0M0.000S"

## Impacted Areas in Application

* Utils#parse_duration