### PR TITLE
remove an unnecessary line

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -376,7 +376,6 @@ module OneLogin
         return false unless validate_response_state
 
         validations = [
-          :validate_response_state,
           :validate_version,
           :validate_id,
           :validate_success_status,


### PR DESCRIPTION
It seems L379 is unnecessary because validate_response_state is already called on L376.
And the method's return value is always true when the program reaches at L378.