### PR TITLE
Replace MAX_BYTE_SIZE constant with setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,6 +816,27 @@ response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], :allowed_cloc
 
 Make sure to keep the value as comfortably small as possible to keep security risks to a minimum.
 
+## Deflation Limit
+
+To protect against decompression bombs (a form of DoS attack), SAML messages are limited to 250,000 bytes by default.
+Sometimes legitimate SAML messages will exceed this limit,
+for example due to custom claims like including groups a user is a member of.
+If you want to customize this limit, you need to provide a different setting when initializing the response object.
+Example:
+
+```ruby
+def consume
+  response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], { settings: saml_settings })
+  ...
+end
+
+private
+
+def saml_settings
+  OneLogin::RubySaml::Settings.new(message_max_bytesize: 500_000)
+end
+```
+
 ## Attribute Service
 
 To request attributes from the IdP the SP needs to provide an attribute service within it's metadata and reference the index in the assertion.

--- a/lib/onelogin/ruby-saml/logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/logoutresponse.rb
@@ -43,7 +43,7 @@ module OneLogin
         end
 
         @options = options
-        @response = decode_raw_saml(response)
+        @response = decode_raw_saml(response, settings)
         @document = XMLSecurity::SignedDocument.new(@response)
       end
 

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -63,7 +63,7 @@ module OneLogin
           end
         end
 
-        @response = decode_raw_saml(response)
+        @response = decode_raw_saml(response, settings)
         @document = XMLSecurity::SignedDocument.new(@response, @errors)
 
         if assertion_encrypted?

--- a/lib/onelogin/ruby-saml/saml_message.rb
+++ b/lib/onelogin/ruby-saml/saml_message.rb
@@ -22,8 +22,6 @@ module OneLogin
       BASE64_FORMAT = %r(\A([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?\Z)
       @@mutex = Mutex.new
 
-      MAX_BYTE_SIZE = 250000
-
       # @return [Nokogiri::XML::Schema] Gets the schema object of the SAML 2.0 Protocol schema
       #
       def self.schema
@@ -88,11 +86,12 @@ module OneLogin
       # @param saml [String] The deflated and encoded SAML Message
       # @return [String] The plain SAML Message
       #
-      def decode_raw_saml(saml)
+      def decode_raw_saml(saml, settings = nil)
         return saml unless base64_encoded?(saml)
 
-        if saml.bytesize > MAX_BYTE_SIZE
-          raise ValidationError.new("Encoded SAML Message exceeds " + MAX_BYTE_SIZE.to_s + " bytes, so was rejected")
+        settings = OneLogin::RubySaml::Settings.new if settings.nil?
+        if saml.bytesize > settings.message_max_bytesize
+          raise ValidationError.new("Encoded SAML Message exceeds " + settings.message_max_bytesize.to_s + " bytes, so was rejected")
         end
 
         decoded = decode(saml)

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -54,6 +54,7 @@ module OneLogin
       attr_accessor :compress_request
       attr_accessor :compress_response
       attr_accessor :double_quote_xml_attribute_values
+      attr_accessor :message_max_bytesize
       attr_accessor :passive
       attr_reader   :protocol_binding
       attr_accessor :attributes_index
@@ -264,6 +265,7 @@ module OneLogin
         :idp_cert_fingerprint_algorithm            => XMLSecurity::Document::SHA1,
         :compress_request                          => true,
         :compress_response                         => true,
+        :message_max_bytesize                      => 250000,
         :soft                                      => true,
         :double_quote_xml_attribute_values         => false,
         :security                                  => {

--- a/lib/onelogin/ruby-saml/slo_logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutrequest.rb
@@ -43,7 +43,7 @@ module OneLogin
           end
         end
 
-        @request = decode_raw_saml(request)
+        @request = decode_raw_saml(request, settings)
         @document = REXML::Document.new(@request)
       end
 

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -17,7 +17,7 @@ class SettingsTest < Minitest::Test
         :idp_attribute_names, :issuer, :assertion_consumer_service_url, :single_logout_service_url,
         :sp_name_qualifier, :name_identifier_format, :name_identifier_value, :name_identifier_value_requested,
         :sessionindex, :attributes_index, :passive, :force_authn,
-        :compress_request, :double_quote_xml_attribute_values,
+        :compress_request, :double_quote_xml_attribute_values, :message_max_bytesize,
         :security, :certificate, :private_key,
         :authn_context, :authn_context_comparison, :authn_context_decl_ref,
         :assertion_consumer_logout_service_url
@@ -89,6 +89,7 @@ class SettingsTest < Minitest::Test
           :idp_slo_service_url => "http://sso.muda.no/slo",
           :idp_slo_service_binding => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
           :idp_cert_fingerprint => "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
+          :message_max_bytesize => 750000,
           :valid_until => '2029-04-16T03:35:08.277Z',
           :name_identifier_format => "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
           :attributes_index => 30,


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
The MAX_BYTE_SIZE constant did not allow for customization, which
is necessary for cases where legitimate SAML responses are larger
than 250,000 bytes. This replaces the constant with a setting, which
has a default value of 250,000 bytes, but can be customized like
any other setting.

This was motivated by https://github.com/onelogin/ruby-saml/issues/598, which was motivated by https://gitlab.com/gitlab-org/gitlab/-/issues/329053.
This follows the [existing pattern used for `encode_raw_saml`](https://github.com/onelogin/ruby-saml/blob/master/lib/onelogin/ruby-saml/saml_message.rb#L111).

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
Introduce MAX_BYTE_SIZE | [link](https://github.com/onelogin/ruby-saml/pull/566/files#diff-6e890879e7944b6cac0e115f001b790f412dc5f6a9a4a11651f70f31c6a33124R25)
Introduce inflate option to disable SAML message inflation | [link](https://github.com/onelogin/ruby-saml/pull/383)

## Todos
- [x] Tests
- [x] Documentation

## Deploy Notes
Nothing noteworthy.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git fetch
git checkout gitlab-djensen:gitlab-djensen-use-setting-for-max-byte-size
bundle install;
ruby -Itest test/settings_test.rb
```

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Settings
* SamlMessage