### PR TITLE
Refactor the OneLogin::RubySaml::Metadata class

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,3 +821,27 @@ end
 ```
 
 The `attribute_value` option additionally accepts an array of possible values.
+
+## Custom Metadata Fields
+
+Some IdPs may require to add SPs to add additional fields (Organization, ContactPerson, etc.)
+into the SP metadata. This can be acheived by extending the `OneLogin::RubySaml::Metadata`
+class and overriding the `#add_extras` method as per the following example:
+
+```ruby
+class MyMetadata < OneLogin::RubySaml::Metadata
+  def add_extras(root, _settings)
+    org = root.add_element("md:Organization")
+    org.add_element("md:OrganizationName", 'xml:lang' => "en-US").text = 'ACME Inc.'
+    org.add_element("md:OrganizationDisplayName", 'xml:lang' => "en-US").text = 'ACME'
+    org.add_element("md:OrganizationURL", 'xml:lang' => "en-US").text = 'https://www.acme.com'
+
+    cp = root.add_element("md:ContactPerson", 'contactType' => 'technical')
+    cp.add_element("md:GivenName").text = 'ACME SAML Team'
+    cp.add_element("md:EmailAddress").text = 'saml@acme.com'
+  end
+end
+
+# Output XML with custom metadata
+MyMetadata.new.generate(settings)
+```

--- a/lib/onelogin/ruby-saml/metadata.rb
+++ b/lib/onelogin/ruby-saml/metadata.rb
@@ -154,6 +154,7 @@ module OneLogin
         return unless settings.security[:metadata_signed] && settings.private_key && settings.certificate
 
         private_key = settings.get_sp_key
+        cert = settings.get_sp_cert
         meta_doc.sign_document(private_key, cert, settings.security[:signature_method], settings.security[:digest_method])
       end
 

--- a/lib/onelogin/ruby-saml/metadata.rb
+++ b/lib/onelogin/ruby-saml/metadata.rb
@@ -151,10 +151,12 @@ module OneLogin
       end
 
       def embed_signature(meta_doc, settings)
-        return unless settings.security[:metadata_signed] && settings.private_key && settings.certificate
+        return unless settings.security[:metadata_signed]
 
         private_key = settings.get_sp_key
         cert = settings.get_sp_cert
+        return unless private_key && cert
+
         meta_doc.sign_document(private_key, cert, settings.security[:signature_method], settings.security[:digest_method])
       end
 

--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -161,10 +161,10 @@ module XMLSecurity
       # add the signature
       issuer_element = self.elements["//saml:Issuer"]
       if issuer_element
-        self.root.insert_after issuer_element, signature_element
+        self.root.insert_after(issuer_element, signature_element)
       else
-        if sp_sso_descriptor = self.elements["/md:EntityDescriptor"]
-          self.root.insert_before sp_sso_descriptor, signature_element
+        if sp_sso_descriptor = self.elements["/md:EntityDescriptor/md:SPSSODescriptor"]
+          self.root.insert_before(sp_sso_descriptor, signature_element)
         else
           self.root.add_element(signature_element)
         end

--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -159,15 +159,13 @@ module XMLSecurity
       x509_cert_element.text = Base64.encode64(certificate.to_der).gsub(/\n/, "")
 
       # add the signature
-      issuer_element = self.elements["//saml:Issuer"]
+      issuer_element = elements["//saml:Issuer"]
       if issuer_element
-        self.root.insert_after(issuer_element, signature_element)
+        root.insert_after(issuer_element, signature_element)
+      elsif first_child = root.children[0]
+        root.insert_before(first_child, signature_element)
       else
-        if sp_sso_descriptor = self.elements["/md:EntityDescriptor/md:SPSSODescriptor"]
-          self.root.insert_before(sp_sso_descriptor, signature_element)
-        else
-          self.root.add_element(signature_element)
-        end
+        root.add_element(signature_element)
       end
     end
 


### PR DESCRIPTION
Fixes #433

- Refactor the OneLogin::RubySaml::Metadata class so it is easier to extend by breaking it into a series of smaller methods.
- Also adds the #add_extras convenience method which is empty but can be extended.
- No change to behavior or to public method surface area.

Example of extending the class:

```ruby
  class MyMetadata < OneLogin::RubySaml::Metadata
    def add_extras(root, _settings)
      org = root.add_element("md:Organization")
      org.add_element("md:OrganizationName", 'xml:lang' => "en-US").text = 'ACME Inc.'
      org.add_element("md:OrganizationDisplayName", 'xml:lang' => "en-US").text = 'ACME'
      org.add_element("md:OrganizationURL", 'xml:lang' => "en-US").text = 'https://www.acme.com'

      cp = root.add_element("md:ContactPerson", 'contactType' => 'technical')
      cp.add_element("md:GivenName").text = 'ACME SAML Team'
      cp.add_element("md:EmailAddress").text = 'saml@acme.com'
    end
  end
```