### PR TITLE
Add test command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In addition, the following may work but are untested:
 * Fork the repository
 * Make your feature addition or bug fix
 * Add tests for your new features. This is important so we don't break any features in a future version unintentionally.
-* Ensure all tests pass.
+* Ensure all tests pass by running `bundle exec rake test`.
 * Do not change rakefile, version, or history.
 * Open a pull request, following [this template](https://gist.github.com/Lordnibbler/11002759).
 


### PR DESCRIPTION
Previously the README did not include the command to run the tests,
so this adds it.