### PR TITLE
Make SLO request signature verification compatible with ADFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 * Support Process Transform
 * Raise SettingError if invoking an action with no endpoint defined on the settings
 * Made IdpMetadataParser more extensible for subclasses
-*[#548](https://github.com/onelogin/ruby-saml/pull/548) Add :skip_audience option
+* [#548](https://github.com/onelogin/ruby-saml/pull/548) Add :skip_audience option
 * [#555](https://github.com/onelogin/ruby-saml/pull/555) Define 'soft' variable to prevent exception when doc cert is invalid
 * Improve documentation
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -9,6 +9,13 @@ to determine how to handle SAML message signing (`HTTP-POST` embeds signature an
 In addition, the `IdpMetadataParser#parse`, `#parse_to_hash` and `#parse_to_array` methods now retrieve
 `idp_sso_service_binding` and `idp_slo_service_binding`.
 
+Following on from the changes in version 1.6.0 to implement the `options[:raw_get_params]` parameter,
+when no raw params are specified, first attempt to build the querystring used for signature verification
+from the ACS URL, which holds the parameters in the way they were encoded by the IdP.  This is more in
+keeping with the SAML spec which indicates that the signature should be derived from a concatenation
+of URI-encoded values _as sent by the IDP_.  This allows for signatures created by Microsoft ADFS and
+Azure Active Directory to work properly as we calculate signature validation.
+
 Lastly, for convenience you may now use the Symbol aliases `:post` and `:redirect` for any `settings.*_binding` parameter.
 
 ## Upgrading from 1.11.x to 1.12.0


### PR DESCRIPTION
(Fixes #470)

Why?
  The Microsoft Azure Active Directory or other ADFS related solutions have implemented
  SAML in a way that CGI-encoded request parameters such as SAMLRequest and SigAlg have
  hexidecimal values represented in lower-case.  This is not in keeping with how the
  vast majority of other SAML implementations operate, and as a result causes
  incompatibility with many environments.  In general it just seems that Microsoft
  likes to be different, and perhaps for dubious reasons.

How?
  In the OneLogin::RubySaml::SloLogoutrequest#validate_signature method, when creating
  raw_get_params and using them to calculate a sha256 hash used for verification,
  first attempt to retrieve any existing query string detail from the ACS URL, which
  will have preserved any non-standard casing which was provided by the IdP.