### PR TITLE
Add security setting to more strictly enforce audience validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,29 @@ validation fails. You may disable such exceptions using the `settings.security[:
   settings.security[:soft] = true  # Do not raise error on failed signature/certificate validations
 ```
 
+#### Audience Validation
+
+A service provider should only consider a SAML response valid if the IdP includes an <AudienceRestriction>
+element containting an <Audience> element that uniquely identifies the service provider. Unless you specify
+the `skip_audience` option, Ruby SAML will validate that each SAML response includes an <Audience> element
+whose contents matches `settings.sp_entity_id`.
+
+By default, Ruby SAML considers an <AudienceRestriction> element containing only empty <Audience> elements
+to be valid. That means an otherwise valid SAML response with a condition like this would be valid:
+
+```xml
+<AudienceRestriction>
+  <Audience />
+</AudienceRestriction>
+```
+
+You may enforce that an <AudienceRestriction> element containing only empty <Audience> elements
+is invalid using the `settings.security[:strict_audience_validation]` parameter.
+
+```ruby
+settings.security[:strict_audience_validation] = true
+```
+
 #### Key Rollover
 
 To update the SP X.509 certificate and private key without disruption of service, you may define the parameter

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -613,7 +613,12 @@ module OneLogin
       #
       def validate_audience
         return true if options[:skip_audience]
-        return true if audiences.empty? || settings.sp_entity_id.nil? || settings.sp_entity_id.empty?
+        return true if settings.sp_entity_id.nil? || settings.sp_entity_id.empty?
+
+        if audiences.empty?
+          return true unless settings.security[:strict_audience_validation]
+          return append_error("Invalid Audiences. The <AudienceRestriction> element contained only empty <Audience> elements. Expected audience #{settings.sp_entity_id}.")
+        end
 
         unless audiences.include? settings.sp_entity_id
           s = audiences.count > 1 ? 's' : '';

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -280,7 +280,8 @@ module OneLogin
           :digest_method              => XMLSecurity::Document::SHA1,
           :signature_method           => XMLSecurity::Document::RSA_SHA1,
           :check_idp_cert_expiration  => false,
-          :check_sp_cert_expiration   => false
+          :check_sp_cert_expiration   => false,
+          :strict_audience_validation => false,
         }.freeze
       }.freeze
     end

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -490,14 +490,22 @@ class RubySamlTest < Minitest::Test
         assert_empty response.errors
       end
 
-      it "return true when the audience is self closing" do
+      it "return true when the audience is self closing and strict audience validation is not enabled" do
         response_audience_self_closed.settings = settings
         response_audience_self_closed.settings.sp_entity_id = '{audience}'
         assert response_audience_self_closed.send(:validate_audience)
         assert_empty response_audience_self_closed.errors
       end
 
-      it "return false when the audience is valid" do
+      it "return false when the audience is self closing and strict audience validation is enabled" do
+        response_audience_self_closed.settings = settings
+        response_audience_self_closed.settings.security[:strict_audience_validation] = true
+        response_audience_self_closed.settings.sp_entity_id = '{audience}'
+        refute response_audience_self_closed.send(:validate_audience)
+        assert_includes response_audience_self_closed.errors, "Invalid Audiences. The <AudienceRestriction> element contained only empty <Audience> elements. Expected audience {audience}."
+      end
+
+      it "return false when the audience is invalid" do
         response.settings = settings
         response.settings.sp_entity_id = 'invalid_audience'
         assert !response.send(:validate_audience)


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Per the [SAML 2.0 Core specification](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf), Section 2.5.1.4, a service provider should expect SAML responses to include an `<AudienceRestriction>` element containing an `<Audience>` element with a URI reference that uniquely identifies the service provider.

Ruby SAML contains logic to validate that responses contain an `<Audience>` element matching `settings.sp_entity_id`. However, if the `<AudienceRestriction>` contains only empty `<Audience>` elements, Ruby SAML skips that validation per https://github.com/onelogin/ruby-saml/pull/444. It seems incorrect that we'd consider a response with a non-empty `<Audience>` element not matching `settings.sp_entity_id` to be invalid, but we'd consider a response with an empty `<Audience>` element (which also wouldn't match `settings.sp_entity_id`) to be valid.

This PR adds a new security option that will consider SAML responses containing only empty `<Audience>` elements to be invalid. By default, this option is not enabled, so it should not be a breaking change.