### PR TITLE
Nokogiri dependencies are different for ruby 2.2

### DIFF
--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency('nokogiri', '>= 1.5.10', '<= 1.6.8.1')
     s.add_runtime_dependency('json', '< 2.3.0')
   elsif RUBY_VERSION < '2.3'
-    s.add_runtime_dependency('nokogiri', '>= 1.9.1', '<= 1.10.0')
+    s.add_runtime_dependency('nokogiri', '>= 1.9.1', '< 1.10.0')
   else
     s.add_runtime_dependency('nokogiri', '>= 1.10.5')
     s.add_runtime_dependency('rexml')


### PR DESCRIPTION
Fix for https://github.com/onelogin/ruby-saml/issues/623