### PR TITLE
Force escape downcasing for Azure SLO

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ However, ruby-saml never enables this dangerous Nokogiri configuration;
 ruby-saml never enables DTDLOAD, and it never disables NONET.
 
 The OneLogin::RubySaml::IdpMetadataParser class does not validate in any way the URL
-that is introduced in order to be parsed. 
+that is introduced in order to be parsed.
 
 Usually the same administrator that handles the Service Provider also sets the URL to
 the IdP, which should be a trusted resource.
@@ -767,7 +767,13 @@ Here is an example that we could add to our previous controller to process a SAM
 # Method to handle IdP initiated logouts
 def idp_logout_request
   settings = Account.get_saml_settings
-  logout_request = OneLogin::RubySaml::SloLogoutrequest.new(params[:SAMLRequest])
+  # ADFS URL-Encodes SAML data as lowercase, and the toolkit by default uses
+  # uppercase. Turn it True for ADFS compatibility on signature verification
+  settings.security[:lowercase_url_encoding] = true
+
+  logout_request = OneLogin::RubySaml::SloLogoutrequest.new(
+    params[:SAMLRequest], settings: settings
+  )
   if !logout_request.is_valid?
     logger.error "IdP initiated LogoutRequest was not valid!"
     return render :inline => logger.error

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -280,7 +280,8 @@ module OneLogin
           :digest_method              => XMLSecurity::Document::SHA1,
           :signature_method           => XMLSecurity::Document::RSA_SHA1,
           :check_idp_cert_expiration  => false,
-          :check_sp_cert_expiration   => false
+          :check_sp_cert_expiration   => false,
+          :lowercase_url_encoding     => false
         }.freeze
       }.freeze
     end

--- a/lib/onelogin/ruby-saml/slo_logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutrequest.rb
@@ -27,7 +27,6 @@ module OneLogin
       # @param options [Hash]  :settings to provide the OneLogin::RubySaml::Settings object
       #                        Or :allowed_clock_drift for the logout request validation process to allow a clock drift when checking dates with
       #                        Or :relax_signature_validation to accept signatures if no idp certificate registered on settings
-      #                        Or :force_escape_downcasing to accept signatures if no idp certificate registered on settings
       #
       # @raise [ArgumentError] If Request is nil
       #
@@ -339,7 +338,7 @@ module OneLogin
 
       def escape_request_param(param)
         CGI.escape(param).tap do |escaped|
-          next unless options[:force_escape_downcasing]
+          next unless settings.security[:lowercase_url_encoding]
 
           escaped.gsub!(/%[A-Fa-f0-9]{2}/) { |match| match.downcase }
         end

--- a/test/slo_logoutrequest_test.rb
+++ b/test/slo_logoutrequest_test.rb
@@ -425,6 +425,52 @@ class RubySamlTest < Minitest::Test
         logout_request_sign_test = OneLogin::RubySaml::SloLogoutrequest.new(params['SAMLRequest'], options)
         assert logout_request_sign_test.send(:validate_signature)
       end
+
+      it "handles Azure AD downcased request encoding" do
+        # Use Logoutrequest only to build the SAMLRequest parameter.
+        settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA256
+        settings.soft = false
+
+        # Creating the query manually to tweak it later instead of using
+        # OneLogin::RubySaml::Utils.build_query
+        request_doc = OneLogin::RubySaml::Logoutrequest.new.create_logout_request_xml_doc(settings)
+        request = Zlib::Deflate.deflate(request_doc.to_s, 9)[2..-5]
+        base64_request = Base64.encode64(request).gsub(/\n/, "")
+        # The original request received from Azure AD comes with downcased
+        # encoded characters, like %2f instead of %2F, and the signature they
+        # send is based on this base64 request.
+        params = {
+          'SAMLRequest' => downcased_escape(base64_request),
+          'SigAlg' => downcased_escape(settings.security[:signature_method]),
+        }
+        # Assemble query string.
+        query = "SAMLRequest=#{params['SAMLRequest']}&SigAlg=#{params['SigAlg']}"
+        # Make normalised signature based on our modified params.
+        sign_algorithm = XMLSecurity::BaseDocument.new.algorithm(
+          settings.security[:signature_method]
+        )
+        signature = settings.get_sp_key.sign(sign_algorithm.new, query)
+        params['Signature'] = downcased_escape(Base64.encode64(signature).gsub(/\n/, ""))
+
+        # Then parameters are usually unescaped, like we manage them in rails
+        params = params.map { |k, v| [k, CGI.unescape(v)] }.to_h
+        # Construct SloLogoutrequest and ask it to validate the signature.
+        # It will fail because the signature is based on the downcased request
+        logout_request_downcased_test = OneLogin::RubySaml::SloLogoutrequest.new(
+          params['SAMLRequest'], get_params: params, settings: settings,
+        )
+        assert_raises(OneLogin::RubySaml::ValidationError, "Invalid Signature on Logout Request") do
+          logout_request_downcased_test.send(:validate_signature)
+        end
+
+        # For this case, the parameters will be forced to be downcased after
+        # being escaped with :force_escape_downcasing option
+        logout_request_force_downcasing_test = OneLogin::RubySaml::SloLogoutrequest.new(
+          params['SAMLRequest'], get_params: params, settings: settings,
+                                 force_escape_downcasing: true
+        )
+        assert logout_request_force_downcasing_test.send(:validate_signature)
+      end
     end
 
     describe "#validate_signature with multiple idp certs" do

--- a/test/slo_logoutrequest_test.rb
+++ b/test/slo_logoutrequest_test.rb
@@ -464,10 +464,10 @@ class RubySamlTest < Minitest::Test
         end
 
         # For this case, the parameters will be forced to be downcased after
-        # being escaped with :force_escape_downcasing option
+        # being escaped with :lowercase_url_encoding security option
+        settings.security[:lowercase_url_encoding] = true
         logout_request_force_downcasing_test = OneLogin::RubySaml::SloLogoutrequest.new(
-          params['SAMLRequest'], get_params: params, settings: settings,
-                                 force_escape_downcasing: true
+          params['SAMLRequest'], get_params: params, settings: settings
         )
         assert logout_request_force_downcasing_test.send(:validate_signature)
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -346,4 +346,9 @@ class Minitest::Test
       end
     end
   end
+
+  # Allows to emulate Azure AD request behavior
+  def downcased_escape(str)
+    CGI.escape(str).gsub(/%[A-Fa-f0-9]{2}/) { |match| match.downcase }
+  end
 end


### PR DESCRIPTION
I followed the [Single Log Out](https://github.com/onelogin/ruby-saml#single-log-out) guide for my Azure AD integration and it worked all good until implementing that `idp_logout_request ` method where I received requests from Azure to log out a user. 
The requests come signed and trying to validate the signature it was failing, then I realised that the problem is that they are encoding the request parameters with downcase encoding characters (like using `%2f` instead of `%2F`) and they use the parameters downcased to generate the signature, therefore in validation time, when signed parameters are restored with `CGI.escape` they were different than the originals sent by Azure (all upcased).
To solve this problem, I added a `force_escape_downcasing` option for `OneLogin::RubySaml::SloLogoutrequest.new`, so all the signature verification is done with downcased encoded parameters.
I'm not sure where to add in the readme this option, specially because the SLO example I followed isn't verifying signed requests, but I'm open to suggestions.