### PR TITLE
Get tests running under Ruby 3.1 and add to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby-version: [2.1.9, 2.2.10, 2.3.8, 2.4.6, 2.5.8, 2.6.6, 2.7.2, 3.0.1, jruby-9.1.17.0, jruby-9.2.17.0, truffleruby]
+        ruby-version: [2.1.9, 2.2.10, 2.3.8, 2.4.6, 2.5.8, 2.6.6, 2.7.2, 3.0.1, '3.1', jruby-9.1.17.0, jruby-9.2.17.0, truffleruby]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('shoulda',  '~> 2.11')
   s.add_development_dependency('simplecov')
   s.add_development_dependency('systemu',  '~> 2')
-  s.add_development_dependency('timecop',  '<= 0.6.0')
+  s.add_development_dependency('timecop',  '~> 0.9')
 
   if defined?(JRUBY_VERSION)
     # All recent versions of JRuby play well with pry

--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -54,7 +54,12 @@ Gem::Specification.new do |s|
   s.add_development_dependency('shoulda',  '~> 2.11')
   s.add_development_dependency('simplecov')
   s.add_development_dependency('systemu',  '~> 2')
-  s.add_development_dependency('timecop',  '~> 0.9')
+
+  if RUBY_VERSION < '2.1'
+    s.add_development_dependency('timecop',  '<= 0.6.0')
+  else
+    s.add_development_dependency('timecop',  '~> 0.9')
+  end
 
   if defined?(JRUBY_VERSION)
     # All recent versions of JRuby play well with pry


### PR DESCRIPTION
As Ruby 3.1 is out it seems like a good idea to get CI running with that version.

There was an issue with Timecop and argument handling that prevented tests from running successfully.  This was due to the gemspec pinning to a very old version of Timecop.  Updating that pin allowed Ruby 3.1 specs to pass without causing any additional spec failures.