### PR TITLE
Raise `ArgumentError` when `nil settings` passed to some methods

### DIFF
--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -95,7 +95,7 @@ module OneLogin
       end
 
       # Creates the SAMLRequest String.
-      # @param settings [OneLogin::RubySaml::Settings|nil] Toolkit settings
+      # @param settings [OneLogin::RubySaml::Settings] Toolkit settings
       # @return [String] The SAMLRequest String.
       #
       def create_authentication_xml_doc(settings)

--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -46,7 +46,7 @@ module OneLogin
       end
 
       # Creates the Get parameters for the request.
-      # @param settings [OneLogin::RubySaml::Settings|nil] Toolkit settings
+      # @param settings [OneLogin::RubySaml::Settings] Toolkit settings
       # @param params [Hash] Some extra parameters to be added in the GET for example the RelayState
       # @return [Hash] Parameters
       #

--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -34,6 +34,8 @@ module OneLogin
       # @return [String] AuthNRequest string that includes the SAMLRequest
       #
       def create(settings, params = {})
+        raise ArgumentError, "Invalid settings, settings should not be nil!" if settings.nil?
+
         params = create_params(settings, params)
         params_prefix = (settings.idp_sso_service_url =~ /\?/) ? '&' : '?'
         saml_request = CGI.escape(params.delete("SAMLRequest"))
@@ -51,6 +53,8 @@ module OneLogin
       # @return [Hash] Parameters
       #
       def create_params(settings, params={})
+        raise ArgumentError, "Invalid settings, settings should not be nil!" if settings.nil?
+
         # The method expects :RelayState but sometimes we get 'RelayState' instead.
         # Based on the HashWithIndifferentAccess value in Rails we could experience
         # conflicts so this line will solve them.
@@ -99,6 +103,8 @@ module OneLogin
       # @return [String] The SAMLRequest String.
       #
       def create_authentication_xml_doc(settings)
+        raise ArgumentError, "Invalid settings, settings should not be nil!" if settings.nil?
+
         document = create_xml_document(settings)
         sign_document(document, settings)
       end

--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -29,7 +29,7 @@ module OneLogin
       end
 
       # Creates the AuthNRequest string.
-      # @param settings [OneLogin::RubySaml::Settings|nil] Toolkit settings
+      # @param settings [OneLogin::RubySaml::Settings] Toolkit settings
       # @param params [Hash] Some extra parameters to be added in the GET for example the RelayState
       # @return [String] AuthNRequest string that includes the SAMLRequest
       #

--- a/lib/onelogin/ruby-saml/logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/logoutrequest.rb
@@ -26,11 +26,13 @@ module OneLogin
       end
 
       # Creates the Logout Request string.
-      # @param settings [OneLogin::RubySaml::Settings|nil] Toolkit settings
+      # @param settings [OneLogin::RubySaml::Settings] Toolkit settings
       # @param params [Hash] Some extra parameters to be added in the GET for example the RelayState
       # @return [String] Logout Request string that includes the SAMLRequest
       #
       def create(settings, params={})
+        raise ArgumentError, "Invalid settings, settings should not be nil!" if settings.nil?
+
         params = create_params(settings, params)
         params_prefix = (settings.idp_slo_service_url =~ /\?/) ? '&' : '?'
         saml_request = CGI.escape(params.delete("SAMLRequest"))
@@ -43,11 +45,13 @@ module OneLogin
       end
 
       # Creates the Get parameters for the logout request.
-      # @param settings [OneLogin::RubySaml::Settings|nil] Toolkit settings
+      # @param settings [OneLogin::RubySaml::Settings] Toolkit settings
       # @param params [Hash] Some extra parameters to be added in the GET for example the RelayState
       # @return [Hash] Parameters
       #
       def create_params(settings, params={})
+        raise ArgumentError, "Invalid settings, settings should not be nil!" if settings.nil?
+
         # The method expects :RelayState but sometimes we get 'RelayState' instead.
         # Based on the HashWithIndifferentAccess value in Rails we could experience
         # conflicts so this line will solve them.
@@ -92,10 +96,12 @@ module OneLogin
       end
 
       # Creates the SAMLRequest String.
-      # @param settings [OneLogin::RubySaml::Settings|nil] Toolkit settings
+      # @param settings [OneLogin::RubySaml::Settings] Toolkit settings
       # @return [String] The SAMLRequest String.
       #
       def create_logout_request_xml_doc(settings)
+        raise ArgumentError, "Invalid settings, settings should not be nil!" if settings.nil?
+
         document = create_xml_document(settings)
         sign_document(document, settings)
       end

--- a/lib/onelogin/ruby-saml/metadata.rb
+++ b/lib/onelogin/ruby-saml/metadata.rb
@@ -12,7 +12,7 @@ module OneLogin
     class Metadata
 
       # Return SP metadata based on the settings.
-      # @param settings [OneLogin::RubySaml::Settings|nil] Toolkit settings
+      # @param settings [OneLogin::RubySaml::Settings] Toolkit settings
       # @param pretty_print [Boolean] Pretty print or not the response
       #                               (No pretty print if you are going to validate the signature)
       # @param valid_until [DateTime] Metadata's valid time
@@ -20,6 +20,8 @@ module OneLogin
       # @return [String] XML Metadata of the Service Provider
       #
       def generate(settings, pretty_print=false, valid_until=nil, cache_duration=nil)
+        raise ArgumentError, "Invalid settings, settings should not be nil!" if settings.nil?
+
         meta_doc = XMLSecurity::Document.new
         add_xml_declaration(meta_doc)
         root = add_root_element(meta_doc, settings, valid_until, cache_duration)

--- a/lib/onelogin/ruby-saml/saml_message.rb
+++ b/lib/onelogin/ruby-saml/saml_message.rb
@@ -100,17 +100,6 @@ module OneLogin
         saml
       end
 
-      # Deflate, base64 encode and url-encode a SAML Message (To be used in the HTTP-redirect binding)
-      # @param saml [String] The plain SAML Message
-      # @param settings [OneLogin::RubySaml::Settings|nil] Toolkit settings
-      # @return [String] The deflated and encoded SAML Message (encoded if the compression is requested)
-      #
-      def encode_raw_saml(saml, settings)
-        saml = deflate(saml) if settings.compress_request
-
-        CGI.escape(encode(saml))
-      end
-
       # Base 64 decode method
       # @param string [String] The string message
       # @return [String] The decoded string

--- a/lib/onelogin/ruby-saml/slo_logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutresponse.rb
@@ -27,7 +27,7 @@ module OneLogin
       end
 
       # Creates the Logout Response string.
-      # @param settings [OneLogin::RubySaml::Settings|nil] Toolkit settings
+      # @param settings [OneLogin::RubySaml::Settings] Toolkit settings
       # @param request_id [String] The ID of the LogoutRequest sent by this SP to the IdP. That ID will be placed as the InResponseTo in the logout response
       # @param logout_message [String] The Message to be placed as StatusMessage in the logout response
       # @param params [Hash] Some extra parameters to be added in the GET for example, the RelayState
@@ -35,6 +35,8 @@ module OneLogin
       # @return [String] Logout Request string that includes the SAMLRequest
       #
       def create(settings, request_id = nil, logout_message = nil, params = {}, logout_status_code = nil)
+        raise ArgumentError, "Invalid settings, settings should not be nil!" if settings.nil?
+
         params = create_params(settings, request_id, logout_message, params, logout_status_code)
         params_prefix = (settings.idp_slo_service_url =~ /\?/) ? '&' : '?'
         url = settings.idp_slo_response_service_url || settings.idp_slo_service_url
@@ -49,7 +51,7 @@ module OneLogin
       end
 
       # Creates the Get parameters for the logout response.
-      # @param settings [OneLogin::RubySaml::Settings|nil] Toolkit settings
+      # @param settings [OneLogin::RubySaml::Settings] Toolkit settings
       # @param request_id [String] The ID of the LogoutRequest sent by this SP to the IdP. That ID will be placed as the InResponseTo in the logout response
       # @param logout_message [String] The Message to be placed as StatusMessage in the logout response
       # @param params [Hash] Some extra parameters to be added in the GET for example, the RelayState
@@ -57,6 +59,8 @@ module OneLogin
       # @return [Hash] Parameters
       #
       def create_params(settings, request_id = nil, logout_message = nil, params = {}, logout_status_code = nil)
+        raise ArgumentError, "Invalid settings, settings should not be nil!" if settings.nil?
+
         # The method expects :RelayState but sometimes we get 'RelayState' instead.
         # Based on the HashWithIndifferentAccess value in Rails we could experience
         # conflicts so this line will solve them.
@@ -101,13 +105,15 @@ module OneLogin
       end
 
       # Creates the SAMLResponse String.
-      # @param settings [OneLogin::RubySaml::Settings|nil] Toolkit settings
+      # @param settings [OneLogin::RubySaml::Settings] Toolkit settings
       # @param request_id [String] The ID of the LogoutRequest sent by this SP to the IdP. That ID will be placed as the InResponseTo in the logout response
       # @param logout_message [String] The Message to be placed as StatusMessage in the logout response
       # @param logout_status_code [String] The StatusCode to be placed as StatusMessage in the logout response
       # @return [String] The SAMLResponse String.
       #
       def create_logout_response_xml_doc(settings, request_id = nil, logout_message = nil, logout_status_code = nil)
+        raise ArgumentError, "Invalid settings, settings should not be nil!" if settings.nil?
+
         document = create_xml_document(settings, request_id, logout_message, logout_status_code)
         sign_document(document, settings)
       end

--- a/test/logoutrequest_test.rb
+++ b/test/logoutrequest_test.rb
@@ -66,6 +66,15 @@ class RequestTest < Minitest::Test
       assert_match %r(#{name_identifier_value}</saml:NameID>), inflated
     end
 
+    describe "when the settings is nil" do
+      it "raises an error with a descriptive message" do
+        err = assert_raises ArgumentError do
+          OneLogin::RubySaml::Logoutrequest.new.create(nil)
+        end
+        assert_match(/settings should not be nil/, err.message)
+      end
+    end
+
     describe "when the target url doesn't contain a query string" do
       it "create the SAMLRequest parameter correctly" do
         unauth_url = OneLogin::RubySaml::Logoutrequest.new.create(settings)
@@ -107,6 +116,20 @@ class RequestTest < Minitest::Test
         assert_match(/^test/, request.uuid)
         OneLogin::RubySaml::Utils::set_prefix("_")
       end
+    end
+
+    it "raises error when settings is nil on create_params" do
+      err = assert_raises ArgumentError do
+        OneLogin::RubySaml::Logoutrequest.new.create_params(nil)
+      end
+      assert_match(/settings should not be nil/, err.message)
+    end
+
+    it "raises error when settings is nil on create_logout_request_xml_doc" do
+      err = assert_raises ArgumentError do
+        OneLogin::RubySaml::Logoutrequest.new.create_logout_request_xml_doc(nil)
+      end
+      assert_match(/settings should not be nil/, err.message)
     end
 
     describe "signing with HTTP-POST binding" do

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -87,6 +87,13 @@ class MetadataTest < Minitest::Test
       assert_equal "PT604800S", REXML::XPath.first(doc_metadata, "//md:EntityDescriptor").attribute("cacheDuration").value
     end
 
+    it "raises error when the settings is nil" do
+      err = assert_raises ArgumentError do
+        OneLogin::RubySaml::Metadata.new.generate(nil)
+      end
+      assert_match(/settings should not be nil/, err.message)
+    end
+
     describe "WantAssertionsSigned" do
       it "generates Service Provider Metadata with WantAssertionsSigned = false" do
         settings.security[:want_assertions_signed] = false

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -176,6 +176,15 @@ class RequestTest < Minitest::Test
       OneLogin::RubySaml::Utils::set_prefix("_")
     end
 
+    describe "when the settings is nil" do
+      it "raises an error with a descriptive message" do
+        err = assert_raises ArgumentError do
+          OneLogin::RubySaml::Authrequest.new.create(nil)
+        end
+        assert_match(/settings should not be nil/, err.message)
+      end
+    end
+
     describe "when the target url is not set" do
       before do
         settings.idp_sso_service_url = nil
@@ -238,6 +247,15 @@ class RequestTest < Minitest::Test
       settings.authn_context_decl_ref = 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'
       auth_doc = OneLogin::RubySaml::Authrequest.new.create_authentication_xml_doc(settings)
       assert_match(/<saml:AuthnContextDeclRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport<\/saml:AuthnContextDeclRef>/, auth_doc.to_s)
+    end
+
+    describe "#create_params signing with nil settings" do
+      it "raises ArgumentError" do
+        err = assert_raises ArgumentError do
+          OneLogin::RubySaml::Authrequest.new.create_params(nil)
+        end
+        assert_match(/settings should not be nil/, err.message)
+      end
     end
 
     describe "#create_params signing with HTTP-POST binding" do
@@ -428,6 +446,13 @@ class RequestTest < Minitest::Test
       auth_doc = OneLogin::RubySaml::Authrequest.new.create_authentication_xml_doc(settings)
       assert auth_doc.to_s =~ /<saml:AuthnContextDeclRef>name\/password\/uri<\/saml:AuthnContextDeclRef>/
       assert auth_doc.to_s =~ /<saml:AuthnContextDeclRef>example\/decl\/ref<\/saml:AuthnContextDeclRef>/
+    end
+
+    it "raises error when settings is nil" do
+      err = assert_raises ArgumentError do
+        OneLogin::RubySaml::Authrequest.new.create_authentication_xml_doc(nil)
+      end
+      assert_match(/settings should not be nil/, err.message)
     end
 
     describe "DEPRECATED: #create_params signing with HTTP-POST binding via :embed_sign" do

--- a/test/saml_message_test.rb
+++ b/test/saml_message_test.rb
@@ -14,17 +14,6 @@ class RubySamlTest < Minitest::Test
       assert logout_request_document, decoded_raw
     end
 
-    it "return encoded raw saml" do
-      settings.compress_request = true
-      encoded_raw = saml_message.send(:encode_raw_saml, logout_request_document, settings)
-      assert logout_request_deflated_base64, encoded_raw
-
-      settings.compress_request = false
-      deflated = saml_message.send(:deflate, logout_request_deflated_base64)
-      encoded_raw = saml_message.send(:encode_raw_saml, deflated, settings)
-      assert logout_request_deflated_base64, encoded_raw
-    end
-
     it "return decoded string" do
       decoded = saml_message.send(:decode, response_document)
       assert response_document_xml, decoded

--- a/test/slo_logoutresponse_test.rb
+++ b/test/slo_logoutresponse_test.rb
@@ -83,6 +83,13 @@ class SloLogoutresponseTest < Minitest::Test
       assert_match(/Destination='http:\/\/unauth.com\/logout\/return'/, inflated)
     end
 
+    it "raises error when the settings is nil" do
+      err = assert_raises ArgumentError do
+        OneLogin::RubySaml::SloLogoutresponse.new.create(nil, logout_request.id)
+      end
+      assert_match(/Invalid settings, settings should not be nil!/, err.message)
+    end
+
     describe "playgin with preix" do
       it "creates request with ID prefixed with default '_'" do
         request = OneLogin::RubySaml::SloLogoutresponse.new
@@ -96,6 +103,20 @@ class SloLogoutresponseTest < Minitest::Test
         assert_match(/^test/, request.uuid)
         OneLogin::RubySaml::Utils::set_prefix("_")
       end
+    end
+
+    it "raises error when settings is nil on create_params" do
+      err = assert_raises ArgumentError do
+        OneLogin::RubySaml::SloLogoutresponse.new.create_params(nil)
+      end
+      assert_match(/Invalid settings, settings should not be nil!/, err.message)
+    end
+
+    it "raises error when settings is nil on create_logout_response_xml_doc" do
+      err = assert_raises ArgumentError do
+        OneLogin::RubySaml::SloLogoutresponse.new.create_logout_response_xml_doc(nil)
+      end
+      assert_match(/Invalid settings, settings should not be nil!/, err.message)
     end
 
     describe "signing with HTTP-POST binding" do

--- a/test/slo_logoutresponse_test.rb
+++ b/test/slo_logoutresponse_test.rb
@@ -85,7 +85,7 @@ class SloLogoutresponseTest < Minitest::Test
 
     it "raises error when the settings is nil" do
       err = assert_raises ArgumentError do
-        OneLogin::RubySaml::SloLogoutresponse.new.create(nil, logout_request.id)
+        OneLogin::RubySaml::SloLogoutresponse.new.create(nil)
       end
       assert_match(/settings should not be nil/, err.message)
     end

--- a/test/slo_logoutresponse_test.rb
+++ b/test/slo_logoutresponse_test.rb
@@ -87,7 +87,7 @@ class SloLogoutresponseTest < Minitest::Test
       err = assert_raises ArgumentError do
         OneLogin::RubySaml::SloLogoutresponse.new.create(nil, logout_request.id)
       end
-      assert_match(/Invalid settings, settings should not be nil!/, err.message)
+      assert_match(/settings should not be nil/, err.message)
     end
 
     describe "playgin with preix" do
@@ -109,14 +109,14 @@ class SloLogoutresponseTest < Minitest::Test
       err = assert_raises ArgumentError do
         OneLogin::RubySaml::SloLogoutresponse.new.create_params(nil)
       end
-      assert_match(/Invalid settings, settings should not be nil!/, err.message)
+      assert_match(/settings should not be nil/, err.message)
     end
 
     it "raises error when settings is nil on create_logout_response_xml_doc" do
       err = assert_raises ArgumentError do
         OneLogin::RubySaml::SloLogoutresponse.new.create_logout_response_xml_doc(nil)
       end
-      assert_match(/Invalid settings, settings should not be nil!/, err.message)
+      assert_match(/settings should not be nil/, err.message)
     end
 
     describe "signing with HTTP-POST binding" do


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description

Several methods across `OneLogin::RubySaml::Authrequest`, `Logoutrequest`, `SloLogoutresponse`, and `Metadata` accepted `nil` as their `settings` argument according to YARD comments (`[OneLogin::RubySaml::Settings|nil]`), but in practice passing `nil` causes a `NoMethodError` immediately when the method tries to call methods on `settings`.

This PR:

- Adds an explicit `ArgumentError` guard at the top of each affected public method, providing a clear error message instead of a cryptic `NoMethodError`
- Corrects the YARD `@param` annotations to remove `|nil`, accurately reflecting that `nil` is not a valid value
- Removes the dead-code private method `encode_raw_saml` from `SamlMessage`

`ArgumentError` was chosen over the library's custom `SettingError` because passing `nil` is a caller-side programming error (wrong argument), whereas `SettingError` is reserved for cases where a settings object exists but contains invalid or missing configuration values.

## Related PRs

N/A

## Todos
- [x] Tests
- [x] Documentation

## Deploy Notes

N/A

## Steps to Test or Reproduce

N/A

## Impacted Areas in Application

- `Authrequest#create`, `#create_params`, `#create_authentication_xml_doc`
- `Logoutrequest#create`, `#create_params`, `#create_logout_request_xml_doc`
- `SloLogoutresponse#create`, `#create_params`, `#create_logout_response_xml_doc`
- `Metadata#generate`